### PR TITLE
Pinned version of one of DBT dependencies. Breaking change introduced…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python-dev \
         python3-pip \
     && pip install --upgrade cffi \
-    && pip install cryptography~=3.4  \
-       dbt-snowflake \
+    && pip install  \
+         # See https://github.com/pallets/markupsafe/issues/282
+         # breaking change introduced in markupsafe causes jinja to break
+         markupsafe==2.0.1 \
+         cryptography~=3.4  \
+         dbt-snowflake \
 	&& rm -r /var/lib/apt/lists/* \
 	&& sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
 	&& locale-gen \


### PR DESCRIPTION
… in markupsafe causes jinja (used by dbt) to break. See https://github.com/pallets/markupsafe/issues/282