### PR TITLE
Fix build image for apple M1

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -11,20 +11,20 @@ WORKDIR /code/
 COPY docker/php-prod.ini /usr/local/etc/php/php.ini
 COPY docker/composer-install.sh /tmp/composer-install.sh
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
         git \
         locales \
         unzip \
         libpq-dev \
-        python-dev \
+        python3 \
         python3-pip \
-    && pip install --upgrade pip cffi \
-    && pip install  \
+    && pip3 install --upgrade pip cffi \
+    && pip3 install \
          # See https://github.com/pallets/markupsafe/issues/282
          # breaking change introduced in markupsafe causes jinja to break
          markupsafe==2.0.1 \
          cryptography~=3.4  \
-         dbt-snowflake \
+         dbt-snowflake~=1.0.1 \
 	&& rm -r /var/lib/apt/lists/* \
 	&& sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
 	&& locale-gen \

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libpq-dev \
         python-dev \
         python3-pip \
-    && pip install --upgrade cffi \
+    && pip install --upgrade pip cffi \
     && pip install  \
          # See https://github.com/pallets/markupsafe/issues/282
          # breaking change introduced in markupsafe causes jinja to break


### PR DESCRIPTION
Fixes https://keboola.atlassian.net/browse/COM-1468

Poladil jsem sestavení balíčků a build na M1 už prochází:
```bash
➜  dbt-transformation git:(eddycek-dockercli-m1-fix) docker-compose build cli                
Building cli
[+] Building 66.3s (14/14) FINISHED                                                                                                                                 
 => [internal] load build definition from Dockerfile-cli                                                                                                       0.0s
 => => transferring dockerfile: 1.47kB                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                              0.0s
 => => transferring context: 34B                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/php:7.4-cli                                                                                                 1.2s
 => [1/9] FROM docker.io/library/php:7.4-cli@sha256:375207e1863f1b595a6a46d7ce2feed82789b97329c49266b7508460ad47823f                                           0.0s
 => [internal] load build context                                                                                                                              0.0s
 => => transferring context: 49.19kB                                                                                                                           0.0s
 => CACHED [2/9] WORKDIR /code/                                                                                                                                0.0s
 => CACHED [3/9] COPY docker/php-prod.ini /usr/local/etc/php/php.ini                                                                                           0.0s
 => CACHED [4/9] COPY docker/composer-install.sh /tmp/composer-install.sh                                                                                      0.0s
 => [5/9] RUN apt-get update && apt-get install -y         git         locales         unzip         libpq-dev         python3         python3-pip     && pi  59.9s
 => [6/9] COPY composer.* /code/                                                                                                                               0.0s
 => [7/9] RUN composer install --prefer-dist --no-interaction --no-dev --no-scripts --no-autoloader                                                            2.1s
 => [8/9] COPY . /code/                                                                                                                                        0.0s
 => [9/9] RUN composer install --prefer-dist --no-interaction --no-dev                                                                                         1.7s
 => exporting to image                                                                                                                                         1.3s
 => => exporting layers                                                                                                                                        1.3s
 => => writing image sha256:454d8fe885b8e09161f30335a4d3dfc05b04bdb319a41dddfd76b85f7fdae4c1                                                                   0.0s
 => => naming to docker.io/keboola/dbt-transformation-cli     
```

Že to funguje se potvrdilo v https://keboola.slack.com/archives/CQ1ASK06M/p1650539447702149?thread_ts=1650523875.932329&cid=CQ1ASK06M