### PR TITLE
Fix undefined offset: 1 in "gitRepository" action when GIT repository…

### DIFF
--- a/src/Service/GitRepositoryService.php
+++ b/src/Service/GitRepositoryService.php
@@ -82,7 +82,12 @@ class GitRepositoryService
         ];
         $process = new Process($args, $projectPath);
         $process->mustRun();
-        $branches = (array) explode("\n", trim($process->getOutput()));
+
+        if (trim($process->getOutput()) !== '') {
+            $branches = (array) explode("\n", trim($process->getOutput()));
+        } else {
+            return [];
+        }
 
         return array_map(function ($item) {
             [$branchRaw, $comment, $sha, $author, $email, $date] = explode(',', $item);

--- a/tests/phpunit/Service/GitRepositoryServiceTest.php
+++ b/tests/phpunit/Service/GitRepositoryServiceTest.php
@@ -69,6 +69,16 @@ class GitRepositoryServiceTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function testListBranchesEmptyGitProject(): void
+    {
+        $gitService = new GitRepositoryService($this->dataDir);
+        $gitService->clone('https://github.com/keboola/empty-repo-test.git');
+        $branches = $gitService->listRemoteBranches($this->dataDir . '/dbt-project');
+
+        self::assertIsArray($branches);
+        self::assertEmpty($branches);
+    }
+
     /**
      * @dataProvider privateRepositoryInvalidCredentials
      */


### PR DESCRIPTION
… is empty

JIRA: https://keboola.atlassian.net/browse/CM-439 a https://keboola.atlassian.net/browse/CM-380

@natocTo Tohle bude chtít asi i handlovat na UI, když sync akce vrátí prázdné pole, vyhodit nějakou hlášku, že repo nemá žádné branche ať si nejdřív initnou dbt project.