### PR TITLE
fix (OutputManifest): columns meta data case issue

### DIFF
--- a/src/FileDumper/OutputManifest.php
+++ b/src/FileDumper/OutputManifest.php
@@ -63,7 +63,7 @@ class OutputManifest
                 $columnName = $column->getColumnName();
                 $columnsMetadata->{$columnName} = array_merge(
                     $column->getColumnDefinition()->toMetadata(),
-                    (array) ($dbtColumnsMetadata[$columnName] ?? [])
+                    (array) ($dbtColumnsMetadata[strtolower($columnName)] ?? [])
                 );
             }
 

--- a/src/FileDumper/OutputManifest/DbtManifestParser.php
+++ b/src/FileDumper/OutputManifest/DbtManifestParser.php
@@ -63,7 +63,7 @@ class DbtManifestParser
                 $columnsMetadata = [];
                 $columns = (array) $tableData['columns'];
                 foreach ($columns as $columnName => $values) {
-                    $columnNameLC = strtolower($columnName);
+                    $columnNameLC = strtolower((string) $columnName);
                     if (isset($values['description'])) {
                         $columnsMetadata[$columnNameLC][] = [
                             'key' => 'KBC.description',

--- a/src/FileDumper/OutputManifest/DbtManifestParser.php
+++ b/src/FileDumper/OutputManifest/DbtManifestParser.php
@@ -63,14 +63,15 @@ class DbtManifestParser
                 $columnsMetadata = [];
                 $columns = (array) $tableData['columns'];
                 foreach ($columns as $columnName => $values) {
+                    $columnNameLC = strtolower($columnName);
                     if (isset($values['description'])) {
-                        $columnsMetadata[$columnName][] = [
+                        $columnsMetadata[$columnNameLC][] = [
                             'key' => 'KBC.description',
                             'value' => $values['description'],
                         ];
                     }
                     if (isset($values['data_type'])) {
-                        $columnsMetadata[$columnName][] = [
+                        $columnsMetadata[$columnNameLC][] = [
                             'key' => 'dbt.data_type',
                             'value' => $values['data_type'],
                         ];
@@ -82,7 +83,7 @@ class DbtManifestParser
                             }
                         }
 
-                        $columnsMetadata[$columnName][] = [
+                        $columnsMetadata[$columnNameLC][] = [
                             'key' => 'dbt.meta',
                             'value' => json_encode($values['meta']),
                         ];

--- a/tests/phpunit/FileDumper/OutputManifest/DbtManifestParserTest.php
+++ b/tests/phpunit/FileDumper/OutputManifest/DbtManifestParserTest.php
@@ -36,5 +36,10 @@ class DbtManifestParserTest extends TestCase
         self::assertArrayHasKey('metadata', $manifest2);
         self::assertArrayHasKey('column_metadata', $manifest2);
         self::assertEquals('beer_id', $manifest2['columns'][0]);
+        self::assertEquals('KBC.description', $manifest1['column_metadata']['brewery_id'][0]['key']);
+        self::assertEquals(
+            'The unique identifier for the brewery',
+            $manifest1['column_metadata']['brewery_id'][0]['value']
+        );
     }
 }

--- a/tests/phpunit/FileDumper/OutputManifest/DbtManifestParserTest.php
+++ b/tests/phpunit/FileDumper/OutputManifest/DbtManifestParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DbtTransformation\Tests\FileDumper\OutputManifest;
 
 use DbtTransformation\FileDumper\OutputManifest\DbtManifestParser;
+use Keboola\Temp\Temp;
 use PHPUnit\Framework\TestCase;
 
 class DbtManifestParserTest extends TestCase
@@ -43,5 +44,39 @@ class DbtManifestParserTest extends TestCase
             'The unique identifier for the brewery',
             $columnMetadata['brewery_id'][0]['value']
         );
+    }
+
+    public function testParseUnifyCase(): void
+    {
+        $temp = new Temp();
+        $tmpFolder = $temp->getTmpFolder();
+
+        $manifest = [
+            'nodes' => [
+                'model.beer_analytics.beers_with_breweries' => [
+                    'resource_type' => 'model',
+                    'name' => 'beers_with_breweries',
+                    'columns' => [
+                        'BREWERY_ID' => [
+                            'name' => 'BREWERY_ID',
+                            'description' => 'The unique identifier for the brewery',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        mkdir(sprintf('%s/target', $tmpFolder));
+        file_put_contents(sprintf('%s/target/manifest.json', $tmpFolder), json_encode($manifest));
+
+        $converter = new DbtManifestParser($tmpFolder);
+        $outputTables = $converter->parse();
+        /** @var array<string, array<array-key, array<string, string>>> $columnsMetadata */
+        $columnsMetadata = $outputTables['beers_with_breweries']['column_metadata'];
+
+        self::assertSame(['brewery_id'], array_keys($columnsMetadata));
+        $metadata = (array) array_shift($columnsMetadata['brewery_id']);
+        self::assertSame('KBC.description', $metadata['key']);
+        self::assertSame('The unique identifier for the brewery', $metadata['value']);
     }
 }

--- a/tests/phpunit/FileDumper/OutputManifest/DbtManifestParserTest.php
+++ b/tests/phpunit/FileDumper/OutputManifest/DbtManifestParserTest.php
@@ -36,10 +36,12 @@ class DbtManifestParserTest extends TestCase
         self::assertArrayHasKey('metadata', $manifest2);
         self::assertArrayHasKey('column_metadata', $manifest2);
         self::assertEquals('beer_id', $manifest2['columns'][0]);
-        self::assertEquals('KBC.description', $manifest1['column_metadata']['brewery_id'][0]['key']);
+        /** @var array<string, array<array-key, array<string, string>>> $columnMetadata */
+        $columnMetadata = $manifest1['column_metadata'];
+        self::assertEquals('KBC.description', $columnMetadata['brewery_id'][0]['key']);
         self::assertEquals(
             'The unique identifier for the brewery',
-            $manifest1['column_metadata']['brewery_id'][0]['value']
+            $columnMetadata['brewery_id'][0]['value']
         );
     }
 }


### PR DESCRIPTION
Toto je fix este k tomu output mappingu, kde sa mohlo stat, ze nazvy sloupcu v DB boli UPPER_CASE ale nazvy sloupcu v dbt manifestu boli lower case a pak to nepridalo ty dbt metadata pro sloupce.