### PR TITLE
fix: get branch id from env - not null even for default branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli
+FROM --platform=linux/amd64 php:8.1-cli-buster
 
 ARG DBT_VERSION=1.4.6
 
@@ -34,21 +34,19 @@ RUN apt-get update && apt-get install -y \
         python3 \
         python3-pip \
         wget \
-    && pip3 install --upgrade pip cffi \
+    && python3 -m pip install --user --upgrade pip \
     && pip3 install \
-         dbt-core==$DBT_VERSION \
-         dbt-snowflake \
-         dbt-postgres \
-         dbt-redshift \
-         dbt-bigquery \
-         dbt-sqlserver \
-    && wget http://archive.ubuntu.com/ubuntu/pool/main/g/glibc/multiarch-support_2.27-3ubuntu1_amd64.deb\
-    && apt-get install ./multiarch-support_2.27-3ubuntu1_amd64.deb \
+        dbt-core==$DBT_VERSION \
+        dbt-snowflake \
+        dbt-postgres \
+        dbt-redshift \
+        dbt-bigquery \
+        dbt-sqlserver
+
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update \
-    && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-        && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
-        && apt-get update -q && ACCEPT_EULA=Y apt-get install -y --no-install-recommends \
-            msodbcsql17 \
+    && ACCEPT_EULA=Y apt-get install -y msodbcsql18 \
     && rm -r /var/lib/apt/lists/* \
 	&& sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \
 	&& locale-gen \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && \
 
 # Now, you can install dbt or any other packages using pip
 RUN pip3 install \
-    dbt-core \
+    dbt-core==$DBT_VERSION \
     dbt-snowflake \
     dbt-postgres \
     dbt-redshift \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,11 @@ RUN apt-get update && apt-get install -y \
         dbt-bigquery \
         dbt-sqlserver
 
+# install git v 2.30
+RUN echo deb http://deb.debian.org/debian buster-backports main | tee /etc/apt/sources.list.d/buster-backports.list \
+    && apt-get update \
+    && apt-get -t buster-backports install -y git
+
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,28 +20,58 @@ WORKDIR /code/
 COPY docker/php-prod.ini /usr/local/etc/php/php.ini
 COPY docker/composer-install.sh /tmp/composer-install.sh
 
-RUN apt-get update && apt-get install -y \
-        git \
-        gpg \
-        gpg-agent \
-        gnupg2 \
-        locales \
-        unzip \
-        libpq-dev \
-        debsig-verify \
-        unixodbc \
-        unixodbc-dev \
-        python3 \
-        python3-pip \
-        wget \
-    && python3 -m pip install --user --upgrade pip \
-    && pip3 install \
-        dbt-core==$DBT_VERSION \
-        dbt-snowflake \
-        dbt-postgres \
-        dbt-redshift \
-        dbt-bigquery \
-        dbt-sqlserver
+RUN apt-get update && \
+    apt-get install -y \
+            wget \
+            build-essential \
+            libssl-dev \
+            zlib1g-dev \
+            libbz2-dev \
+            libreadline-dev \
+            libsqlite3-dev \
+            llvm \
+            libncurses5-dev \
+            libncursesw5-dev \
+            xz-utils \
+            tk-dev \
+            libffi-dev \
+            liblzma-dev \
+            python3-openssl \
+            git \
+            gpg-agent \
+            gnupg2 \
+            locales \
+            unzip \
+            libpq-dev \
+            debsig-verify \
+            unixodbc \
+            unixodbc-dev \
+    && apt-get clean
+
+# Compile and install Python 3.8 from source
+RUN wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz && \
+    tar -xvf Python-3.8.12.tgz && \
+    cd Python-3.8.12 && \
+    ./configure --enable-optimizations && \
+    make -j$(nproc) && \
+    make altinstall && \
+    cd .. && rm -rf Python-3.8.12 && rm Python-3.8.12.tgz
+
+# Set Python 3.8 as the default Python version
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.8 1
+
+# Install pip for the new Python version
+RUN wget https://bootstrap.pypa.io/get-pip.py && \
+    python3.8 get-pip.py && rm get-pip.py
+
+# Now, you can install dbt or any other packages using pip
+RUN pip3 install \
+    dbt-core \
+    dbt-snowflake \
+    dbt-postgres \
+    dbt-redshift \
+    dbt-bigquery \
+    dbt-sqlserver
 
 # install git v 2.30
 RUN echo deb http://deb.debian.org/debian buster-backports main | tee /etc/apt/sources.list.d/buster-backports.list \

--- a/src/Component.php
+++ b/src/Component.php
@@ -239,7 +239,7 @@ class Component extends BaseComponent
 
         $componentId = (string) (getenv('KBC_COMPONENTID') ?: self::COMPONENT_ID);
         $configId = $this->getConfig()->getConfigId();
-        $branchId = $this->getConfig()->getBranchId();
+        $branchId = $this->getConfig()->getEnvKbcBranchId();
 
         if ($isArchive) {
             $this->artifacts->downloadLastRun($componentId, $configId, $branchId);
@@ -268,9 +268,9 @@ class Component extends BaseComponent
         $artifactsOptions = $this->getConfig()->getArtifactsOptions();
         $isArchive = $artifactsOptions['zip'] ?? true;
 
-        $componentId = getenv('KBC_COMPONENTID') ?: self::COMPONENT_ID;
+        $componentId = (string) getenv('KBC_COMPONENTID') ?: self::COMPONENT_ID;
         $configId = $this->getConfig()->getConfigId();
-        $branchId = $this->getConfig()->getBranchId();
+        $branchId = $this->getConfig()->getEnvKbcBranchId();
 
         if ($isArchive) {
             $this->artifacts->downloadLastRun($componentId, $configId, $branchId);
@@ -302,9 +302,9 @@ class Component extends BaseComponent
         $artifactsOptions = $this->getConfig()->getArtifactsOptions();
         $isArchive = $artifactsOptions['zip'] ?? true;
 
-        $componentId = getenv('KBC_COMPONENTID') ?: self::COMPONENT_ID;
+        $componentId = (string) getenv('KBC_COMPONENTID') ?: self::COMPONENT_ID;
         $configId = $this->getConfig()->getConfigId();
-        $branchId = $this->getConfig()->getBranchId();
+        $branchId = $this->getConfig()->getEnvKbcBranchId();
 
         if ($isArchive) {
             $this->artifacts->downloadLastRun($componentId, $configId, $branchId);

--- a/src/DwhProvider/RemoteMssqlProvider.php
+++ b/src/DwhProvider/RemoteMssqlProvider.php
@@ -13,7 +13,7 @@ class RemoteMssqlProvider extends RemoteSnowflakeProvider implements DwhProvider
         $workspace = $this->config->getRemoteDwh();
 
         putenv(sprintf('DBT_KBC_PROD_TYPE=%s', $workspace['type']));
-        putenv(sprintf('DBT_KBC_PROD_DRIVER=%s', 'ODBC Driver 17 for SQL Server'));
+        putenv(sprintf('DBT_KBC_PROD_DRIVER=%s', 'ODBC Driver 18 for SQL Server'));
         putenv(sprintf('DBT_KBC_PROD_TRUST_CERT=%s', 'True'));
         putenv(sprintf('DBT_KBC_PROD_SERVER=%s', $workspace['server']));
         putenv(sprintf('DBT_KBC_PROD_PORT=%s', $workspace['port']));

--- a/tests/functional/run-action-with-debug-step/expected-stdout
+++ b/tests/functional/run-action-with-debug-step/expected-stdout
@@ -5,8 +5,8 @@ Warning: No packages were found in packages.yml
 Executing command "dbt debug"
 Running with dbt=%s
 dbt version: %s
-python version: 3.7.3
-python path: /usr/bin/python3
+python version: 3.8.12
+python path: /usr/local/bin/python3.8
 os info: %s
 Using profiles.yml file at /tmp/%s/dbt-project/profiles.yml
 Using dbt_project.yml file at /tmp/%s/dbt-project/dbt_project.yml%A

--- a/tests/functional/run-action-with-debug-step/expected-stdout
+++ b/tests/functional/run-action-with-debug-step/expected-stdout
@@ -5,7 +5,7 @@ Warning: No packages were found in packages.yml
 Executing command "dbt debug"
 Running with dbt=%s
 dbt version: %s
-python version: 3.9.2
+python version: 3.7.3
 python path: /usr/bin/python3
 os info: %s
 Using profiles.yml file at /tmp/%s/dbt-project/profiles.yml

--- a/tests/functionalSyncActions/DatadirTest.php
+++ b/tests/functionalSyncActions/DatadirTest.php
@@ -6,10 +6,12 @@ namespace DbtTransformation\FunctionalSyncActionsTests;
 
 use DbtTransformation\Component;
 use Keboola\DatadirTests\DatadirTestCase;
+use Keboola\DatadirTests\Exception\DatadirTestsException;
 use Keboola\StorageApi\Client as StorageClient;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\Process\Process;
 
 class DatadirTest extends DatadirTestCase
 {
@@ -35,6 +37,34 @@ class DatadirTest extends DatadirTestCase
         $storageClient->uploadFile(__DIR__ . '/../phpunit/data/artifacts.tar.gz', $options);
 
         sleep(1);
+    }
+
+    protected function runScript(string $datadirPath, ?string $runId = null): Process
+    {
+        $fs = new Filesystem();
+
+        $script = $this->getScript();
+        if (!$fs->exists($script)) {
+            throw new DatadirTestsException(sprintf(
+                'Cannot open script file "%s"',
+                $script
+            ));
+        }
+
+        $runCommand = [
+            'php',
+            $script,
+        ];
+        $runProcess = new Process($runCommand);
+        $defaultRunId = random_int(1000, 100000) . '.' . random_int(1000, 100000) . '.' . random_int(1000, 100000);
+        $runProcess->setEnv([
+            'KBC_DATADIR' => $datadirPath,
+            'KBC_RUNID' => $runId ?? $defaultRunId,
+            'KBC_BRANCHID' => getenv('KBC_BRANCHID') ?: '',
+        ]);
+        $runProcess->setTimeout(0.0);
+        $runProcess->run();
+        return $runProcess;
     }
 
     public function tearDown(): void

--- a/tests/functionalSyncActions/DatadirTest.php
+++ b/tests/functionalSyncActions/DatadirTest.php
@@ -17,10 +17,12 @@ class DatadirTest extends DatadirTestCase
     {
         parent::setUp();
 
+        putenv('KBC_BRANCHID=12345');
+
         $options = new FileUploadOptions();
         $options->setTags([
             'artifact',
-            'branchId-default',
+            'branchId-12345',
             'componentId-' . Component::COMPONENT_ID,
             'configId-12345',
             'jobId-123',

--- a/tests/functionalSyncActionsNoZip/DatadirTest.php
+++ b/tests/functionalSyncActionsNoZip/DatadirTest.php
@@ -19,10 +19,12 @@ class DatadirTest extends DatadirTestCase
     {
         parent::setUp();
 
+        putenv('KBC_BRANCHID=12345');
+
         $options = new FileUploadOptions();
         $options->setTags([
             'artifact',
-            'branchId-default',
+            'branchId-12345',
             'componentId-' . Component::COMPONENT_ID,
             'configId-12345',
             'jobId-123',


### PR DESCRIPTION
Artefakty se uploaduji v Docker Bundlu, ktery je ted otaguje nenullovym branchId i v pripade, ze je to default branch. 

Komponenta `dbt-transformace` si artefakty pak stahuje v sync akci a branchId dostane i jako parametr, ktery je ale null pro default branch (posila se z UI). 

Kdyz ale pouzijeme KBC_BRANCHID env, ten by mel byt nenullovy i pro default branch.