### PR TITLE
Fallback to info logs when error occurs but no errors are present in logs.

### DIFF
--- a/src/Service/DbtService.php
+++ b/src/Service/DbtService.php
@@ -47,6 +47,9 @@ class DbtService
                 throw new UserException($e->getProcess()->getErrorOutput());
             }
             $logs = iterator_to_array(ParseDbtOutputHelper::getMessagesFromOutput($output, 'error'));
+            if (empty($logs)) {
+                $logs = iterator_to_array(ParseDbtOutputHelper::getMessagesFromOutput($output));
+            }
             throw new UserException(implode(PHP_EOL, $logs));
         }
     }


### PR DESCRIPTION
JIRA: https://keboola.atlassian.net/browse/CM-744

V určitých případech (nevalidní JSON s credentials k BQ DB) končil job chybou, ale chyba se nezobrazila. Nakonec se mi to podařilo zreplikovat a z nějakého důvod má ta chyba log level `info`. Přidal jsem tedy fallback.