### PR TITLE
feat: add dbt logging improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+## Project Overview
+
+PHP 8.3+ Keboola component that runs dbt (data build tool) transformations across data warehouses (Snowflake, BigQuery, PostgreSQL, MSSQL, Redshift). Entry point is `src/run.php` → `src/Component.php`.
+
+## Build & Test Commands
+
+```bash
+# Full CI pipeline (lint + cs + static analysis + tests)
+composer ci
+
+# Individual checks
+composer phplint          # PHP syntax check
+composer phpcs            # Coding standards (Keboola ruleset)
+composer phpcbf           # Auto-fix coding standards
+composer phpstan          # Static analysis (level max)
+composer tests-phpunit    # Unit tests
+
+# Functional tests (require environment variables / Docker services)
+composer tests-datadir
+composer tests-datadir-remote-dwh
+composer tests-datadir-sync-actions
+```
+
+## Code Conventions
+
+- Every file must start with `declare(strict_types=1);`
+- Use full PHP 8.3 type hints on all parameters and return types
+- Coding standard: `vendor/keboola/coding-standard/src/ruleset.xml` (enforced by phpcs)
+- PHPStan level: max
+- Use doc-blocks for describing array shapes for PHPStan (e.g., `@return array<string, string>`)
+- Minimize usage of `mixed` type in doc-block annotations
+- Constructor promotion with `readonly` where appropriate
+- Use `match` expressions over `switch` for control flow
+
+## Architecture Patterns
+
+- **Component pattern**: Main class extends `Keboola\Component\BaseComponent`, config extends `BaseConfig`
+- **Factory pattern**: `DwhProviderFactory` instantiates warehouse providers via `match` on `DwhConnectionTypeEnum`
+- **Interface-based providers**: All DWH providers implement `DwhProviderInterface`
+- **Symfony Config**: Node definitions use `ArrayNodeDefinition` fluent builders
+- **Exception handling**: Use `Keboola\Component\UserException` for user-facing errors
+
+## Namespace Structure
+
+```
+DbtTransformation\              → src/
+DbtTransformation\Tests\        → tests/phpunit/
+DbtTransformation\FunctionalTests\ → tests/functional/
+```
+
+## Test Conventions
+
+- **Every new functionality MUST be covered with tests**
+- Unit tests in `tests/phpunit/`, extending `PHPUnit\Framework\TestCase`
+- Test classes named `*Test.php` mirroring source structure
+- Functional tests use datadir pattern with `setUp.php`/`tearDown.php`
+- Functional tests compare stdout against `expected-stdout` files using PHPUnit format strings (`%s`, `%S`, `%A`, `%a`, `%w`). When changing output (e.g., adding log lines), update ALL `tests/functional/*/expected-stdout` files
+- Environment variables for credentials loaded via `tests/phpunit/bootstrap.php`
+- Config definition tests in `ConfigDefinitionTest.php` — when adding config options, update `addDefaultValues()` helper and add both valid config data provider cases and dedicated getter tests
+
+## Docker
+
+- Base image: `php:8.3-cli-trixie`
+- Includes Python 3.11.9 (compiled from source) for dbt
+- Database drivers: Snowflake ODBC, MS SQL ODBC, PostgreSQL ODBC
+- Use `docker compose` for local development with service dependencies
+
+## CI
+
+- GitHub Actions workflow at `.github/workflows/push.yml`
+- Build matrix tests against multiple dbt versions (1.8.6, 1.10.17, 1.11.2)
+- Deploys to ECR on semantic version tags

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The configuration `config.json` contains following properties in `parameters` ke
         - `period` - positive integer: Number of periods where a data source is still considered "fresh".
         - `count` - string enum: The time period used in the freshness calculation. One of `minute`, `hour` or `day`.
 - `showExecutedSqls` - boolean (optional): Default `false`, if set to `true` SQL queries executed by DBT transformation are printed to output.
+
+### Debug Mode
+
+Running the job in **debug mode** enables more verbose logging — the full `dbt.log` is streamed to output after each step. Additionally, the generated `profiles.yml` is always logged (with sensitive values masked) to help diagnose connection issues.
 - `generateSources` - boolean (optional): Default `true`
   - If `true` sources YAML files are generated. 
   - If `false` generating of sources file is skipped. 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "keboola/datadir-tests": "^5.2",
         "keboola/php-temp": "^2.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",
-        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan": "^1.12",
         "phpunit/phpunit": "^9.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a93ce77b3735d5db938a7af7124911e3",
+    "content-hash": "c7bd50c19f74b07a66f827224c455bac",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -5310,16 +5310,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d"
-            },
+            "version": "1.12.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/52d2bbfdcae7f895915629e4694e9497d0f8e28d",
-                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
                 "shasum": ""
             },
             "require": {
@@ -5364,7 +5359,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-06T11:17:41+00:00"
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6958,5 +6953,5 @@
         "ext-odbc": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/Component.php
+++ b/src/Component.php
@@ -528,9 +528,13 @@ class Component extends BaseComponent
             throw new UserException('Absolute path in --profiles-dir option is not allowed.');
         }
 
-        $profilesDir = ltrim($profilesDir, '.');
+        $profilesDir = ltrim($profilesDir, './');
 
-        return $this->projectPath . $profilesDir;
+        if ($profilesDir === '') {
+            return $this->projectPath;
+        }
+
+        return rtrim($this->projectPath, '/') . '/' . $profilesDir;
     }
 
     public static function setEnvironment(): void

--- a/src/Component.php
+++ b/src/Component.php
@@ -20,7 +20,9 @@ use DbtTransformation\Helper\DbtCompileHelper;
 use DbtTransformation\Helper\DbtDocsHelper;
 use DbtTransformation\Helper\ParseDbtOutputHelper;
 use DbtTransformation\Helper\ParseLogFileHelper;
+use DbtTransformation\Helper\ProfilesHelper;
 use DbtTransformation\Service\ArtifactsService;
+use DbtTransformation\Service\DbtLogService;
 use DbtTransformation\Service\DbtService;
 use DbtTransformation\Service\GitRepositoryService;
 use ErrorException;
@@ -87,15 +89,31 @@ class Component extends BaseComponent
         $executeSteps = $config->getExecuteSteps();
         array_unshift($executeSteps, 'dbt deps');
 
+        $isDebugMode = getenv('KBC_COMPONENT_RUN_MODE') === 'debug';
+
         if ($provider->getDwhConnectionType() === DwhConnectionTypeEnum::REMOTE) {
             $profilesDir = $this->getProfilesPath($executeSteps);
             $provider->createDbtYamlFiles($profilesDir);
+            $this->logProfilesYaml($profilesDir);
         } else {
             $provider->createDbtYamlFiles($this->projectPath);
+            $this->logProfilesYaml($this->projectPath);
         }
 
-        foreach ($executeSteps as $step) {
-            $this->executeStep($step, $provider->getDwhConnectionType());
+        $dbtLogService = new DbtLogService($this->getLogger(), $this->projectPath . '/logs/dbt.log');
+
+        try {
+            foreach ($executeSteps as $step) {
+                $this->executeStep($step, $provider->getDwhConnectionType());
+
+                if ($isDebugMode) {
+                    $dbtLogService->log();
+                }
+            }
+        } finally {
+            if ($isDebugMode) {
+                $dbtLogService->log();
+            }
         }
         if ($config->showSqls()) {
             $this->logExecutedSqls();
@@ -209,6 +227,23 @@ class Component extends BaseComponent
         ));
     }
 
+    protected function logProfilesYaml(string $profilesDir): void
+    {
+        $profilesPath = sprintf('%s/profiles.yml', $profilesDir);
+        if (!file_exists($profilesPath)) {
+            return;
+        }
+
+        $profiles = Yaml::parseFile($profilesPath);
+        if (!is_array($profiles)) {
+            return;
+        }
+
+        $resolved = ProfilesHelper::resolveEnvVars($profiles);
+        $masked = ProfilesHelper::maskSensitiveValues($resolved);
+        $this->getLogger()->info(sprintf("Generated profiles.yml:\n%s", Yaml::dump($masked, 5)));
+    }
+
     protected function logExecutedSqls(): void
     {
         $sqls = (new ParseLogFileHelper(sprintf('%s/logs/dbt.log', $this->projectPath)))->getSqls();
@@ -224,7 +259,7 @@ class Component extends BaseComponent
     protected function executeStep(string $step, DwhConnectionTypeEnum $dwhConnectionType): void
     {
         $this->getLogger()->info(sprintf('Executing command "%s"', $step));
-        $dbtService = new DbtService($this->projectPath, $dwhConnectionType);
+        $dbtService = new DbtService($this->projectPath, $dwhConnectionType, $this->getLogger());
         if ($step === DbtService::COMMAND_DEPS) {
             //some deps could be installed from git, so retry for "shallow file has changed" is needed
             /** @var string $output */
@@ -322,6 +357,7 @@ class Component extends BaseComponent
                 $this->artifacts->downloadLastRun($componentId, $configId, $branchId);
 
                 $manifestJson = $this->artifacts->readFromFileInStep(DbtService::COMMAND_RUN, 'manifest.json');
+                /** @var array<string, mixed> $manifest */
                 $manifest = (array) json_decode($manifestJson, true, 512, JSON_THROW_ON_ERROR);
                 $runResultsJson = $this->artifacts->readFromFileInStep(DbtService::COMMAND_RUN, 'run_results.json');
                 /** @var array<string, array<string, mixed>> $runResults */

--- a/src/Component.php
+++ b/src/Component.php
@@ -37,6 +37,7 @@ use Psr\Log\LoggerInterface;
 use Retry\Policy\CallableRetryPolicy;
 use Retry\RetryProxy;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 use Throwable;
 
@@ -234,7 +235,13 @@ class Component extends BaseComponent
             return;
         }
 
-        $profiles = Yaml::parseFile($profilesPath);
+        try {
+            $profiles = Yaml::parseFile($profilesPath);
+        } catch (ParseException $e) {
+            $this->getLogger()->warning(sprintf('Could not parse profiles.yml for logging: %s', $e->getMessage()));
+            return;
+        }
+
         if (!is_array($profiles)) {
             return;
         }

--- a/src/Component.php
+++ b/src/Component.php
@@ -112,6 +112,7 @@ class Component extends BaseComponent
                 }
             }
         } finally {
+            // Ensure dbt.log is flushed on failure; on success this is a no-op (offset already at EOF)
             if ($isDebugMode) {
                 $dbtLogService->log();
             }

--- a/src/Helper/ProfilesHelper.php
+++ b/src/Helper/ProfilesHelper.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DbtTransformation\Helper;
+
+class ProfilesHelper
+{
+    private const SENSITIVE_KEYS = [
+        'password',
+        'private_key',
+        'keyfile',
+        'key_content',
+        'token',
+        'client_secret',
+    ];
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    public static function maskSensitiveValues(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $data[$key] = self::maskSensitiveValues($value);
+            } elseif (is_string($key) && in_array(strtolower($key), self::SENSITIVE_KEYS, true)) {
+                $data[$key] = '****';
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Resolves {{ env_var("...") }} references to actual environment variable values.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    public static function resolveEnvVars(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_array($value)) {
+                $data[$key] = self::resolveEnvVars($value);
+            } elseif (is_string($value)) {
+                $data[$key] = self::resolveEnvVarString($value);
+            }
+        }
+
+        return $data;
+    }
+
+    private static function resolveEnvVarString(string $value): string|int
+    {
+        $pattern = '/\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*(?:\|\s*as_number\s*)?\}\}/';
+
+        if (preg_match('/^\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*\|\s*as_number\s*\}\}$/', $value, $matches)) {
+            $envValue = getenv($matches[1]);
+            return $envValue !== false ? (int) $envValue : $value;
+        }
+
+        return (string) preg_replace_callback($pattern, function (array $matches): string {
+            $envValue = getenv($matches[1]);
+            return $envValue !== false ? $envValue : $matches[0];
+        }, $value);
+    }
+}

--- a/src/Helper/ProfilesHelper.php
+++ b/src/Helper/ProfilesHelper.php
@@ -9,9 +9,12 @@ class ProfilesHelper
     private const SENSITIVE_KEYS = [
         'password',
         'private_key',
+        'private_key_passphrase',
         'keyfile',
+        'keyfile_json',
         'key_content',
         'token',
+        'secret',
         'client_secret',
     ];
 
@@ -51,24 +54,30 @@ class ProfilesHelper
         return $data;
     }
 
-    private static function resolveEnvVarString(string $value): string|int|bool
+    private static function resolveEnvVarString(string $value): string|int|float|bool
     {
-        $pattern = '/\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*(?:\|\s*(as_number|as_bool)\s*)?\}\}/';
+        $envVarPattern = '/\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*(?:\|\s*(as_number|as_bool)\s*)?\}\}/';
 
-        if (preg_match('/^\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*\|\s*(as_number|as_bool)\s*\}\}$/', $value, $matches)) {
+        // Full-value env_var with filter — cast to the appropriate type
+        if (preg_match('/^' . substr($envVarPattern, 1, -1) . '$/', $value, $matches)
+            && isset($matches[2]) && $matches[2] !== ''
+        ) {
             $envValue = getenv($matches[1]);
             if ($envValue === false) {
                 return $value;
             }
 
             return match ($matches[2]) {
-                'as_number' => is_numeric($envValue) ? (int) $envValue : $envValue,
+                'as_number' => is_numeric($envValue)
+                    ? (str_contains($envValue, '.') ? (float) $envValue : (int) $envValue)
+                    : $envValue,
                 'as_bool' => filter_var($envValue, FILTER_VALIDATE_BOOLEAN),
                 default => $envValue,
             };
         }
 
-        return (string) preg_replace_callback($pattern, function (array $matches): string {
+        // Inline env_var references (possibly embedded in a larger string) — resolve as strings
+        return (string) preg_replace_callback($envVarPattern, function (array $matches): string {
             $envValue = getenv($matches[1]);
             return $envValue !== false ? $envValue : $matches[0];
         }, $value);

--- a/src/Helper/ProfilesHelper.php
+++ b/src/Helper/ProfilesHelper.php
@@ -51,13 +51,21 @@ class ProfilesHelper
         return $data;
     }
 
-    private static function resolveEnvVarString(string $value): string|int
+    private static function resolveEnvVarString(string $value): string|int|bool
     {
-        $pattern = '/\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*(?:\|\s*as_number\s*)?\}\}/';
+        $pattern = '/\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*(?:\|\s*(as_number|as_bool)\s*)?\}\}/';
 
-        if (preg_match('/^\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*\|\s*as_number\s*\}\}$/', $value, $matches)) {
+        if (preg_match('/^\{\{\s*env_var\(\s*"([^"]+)"\s*\)\s*\|\s*(as_number|as_bool)\s*\}\}$/', $value, $matches)) {
             $envValue = getenv($matches[1]);
-            return $envValue !== false ? (int) $envValue : $value;
+            if ($envValue === false) {
+                return $value;
+            }
+
+            return match ($matches[2]) {
+                'as_number' => is_numeric($envValue) ? (int) $envValue : $envValue,
+                'as_bool' => filter_var($envValue, FILTER_VALIDATE_BOOLEAN),
+                default => $envValue,
+            };
         }
 
         return (string) preg_replace_callback($pattern, function (array $matches): string {

--- a/src/Helper/ProfilesHelper.php
+++ b/src/Helper/ProfilesHelper.php
@@ -72,7 +72,6 @@ class ProfilesHelper
                     ? (str_contains($envValue, '.') ? (float) $envValue : (int) $envValue)
                     : $envValue,
                 'as_bool' => filter_var($envValue, FILTER_VALIDATE_BOOLEAN),
-                default => $envValue,
             };
         }
 

--- a/src/Service/ArtifactsService.php
+++ b/src/Service/ArtifactsService.php
@@ -97,6 +97,7 @@ class ArtifactsService
                         file_put_contents($artifactsPath . '/compiled_sql.json', $compiledSqlContent);
 
                         $manifestJson = (string) file_get_contents($targetPath . '/manifest.json');
+                        /** @var array<string, mixed> $manifest */
                         $manifest = (array) json_decode($manifestJson, true, 512, JSON_THROW_ON_ERROR);
                         $runResultsJson = (string) file_get_contents($targetPath . '/run_results.json');
                         /** @var array<string, array<string, mixed>> $runResults */

--- a/src/Service/DbtLogService.php
+++ b/src/Service/DbtLogService.php
@@ -41,7 +41,7 @@ class DbtLogService
         fseek($handle, $this->offset);
 
         while (($line = fgets($handle)) !== false) {
-            $line = trim($line);
+            $line = rtrim($line, "\r\n");
             if ($line !== '') {
                 $this->logger->info($line);
             }

--- a/src/Service/DbtLogService.php
+++ b/src/Service/DbtLogService.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DbtTransformation\Service;
+
+use Psr\Log\LoggerInterface;
+
+class DbtLogService
+{
+    private int $offset = 0;
+
+    public function __construct(
+        private readonly LoggerInterface $logger,
+        private readonly string $logFilePath,
+    ) {
+    }
+
+    public function log(): void
+    {
+        clearstatcache(true, $this->logFilePath);
+
+        if (!file_exists($this->logFilePath)) {
+            return;
+        }
+
+        $fileSize = filesize($this->logFilePath);
+        if ($fileSize === false) {
+            return;
+        }
+
+        if ($fileSize < $this->offset) {
+            $this->offset = 0;
+        }
+
+        $handle = fopen($this->logFilePath, 'r');
+        if ($handle === false) {
+            return;
+        }
+
+        fseek($handle, $this->offset);
+
+        while (($line = fgets($handle)) !== false) {
+            $line = trim($line);
+            if ($line !== '') {
+                $this->logger->info($line);
+            }
+        }
+
+        $this->offset = (int) ftell($handle);
+        fclose($handle);
+    }
+}

--- a/src/Service/DbtService.php
+++ b/src/Service/DbtService.php
@@ -7,6 +7,7 @@ namespace DbtTransformation\Service;
 use DbtTransformation\DwhProvider\DwhConnectionTypeEnum;
 use DbtTransformation\Helper\ParseDbtOutputHelper;
 use Keboola\Component\UserException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -35,6 +36,7 @@ class DbtService
     public function __construct(
         private readonly string $projectPath,
         private readonly DwhConnectionTypeEnum $dwhConnectionType,
+        private readonly ?LoggerInterface $logger = null,
     ) {
     }
 
@@ -49,9 +51,14 @@ class DbtService
             $process->mustRun();
             return $process->getOutput();
         } catch (ProcessFailedException $e) {
+            $errorOutput = $e->getProcess()->getErrorOutput();
+            if ($errorOutput !== '' && $this->logger !== null) {
+                $this->logger->error(sprintf('dbt stderr: %s', $errorOutput));
+            }
+
             $output = $e->getProcess()->getOutput();
             if ($output === '') {
-                throw new UserException($e->getProcess()->getErrorOutput());
+                throw new UserException($errorOutput);
             }
             $logs = iterator_to_array(ParseDbtOutputHelper::getMessagesFromOutput($output, 'error'));
             if (empty($logs)) {

--- a/tests/functional/run-action-native-types-manifest/expected-stdout
+++ b/tests/functional/run-action-native-types-manifest/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-native-types-manifest/expected-stdout
+++ b/tests/functional/run-action-native-types-manifest/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-new-steps-structure/expected-stdout
+++ b/tests/functional/run-action-new-steps-structure/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in 0 hours 0 minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-new-steps-structure/expected-stdout
+++ b/tests/functional/run-action-new-steps-structure/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in 0 hours 0 minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-debug-step/expected-stdout
+++ b/tests/functional/run-action-with-debug-step/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt debug"
+%AExecuting command "dbt debug"
 Running with dbt=%A
 dbt version: %A
 python version: 3.11.9

--- a/tests/functional/run-action-with-debug-step/expected-stdout
+++ b/tests/functional/run-action-with-debug-step/expected-stdout
@@ -1,4 +1,5 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml

--- a/tests/functional/run-action-with-deps/expected-stdout
+++ b/tests/functional/run-action-with-deps/expected-stdout
@@ -1,4 +1,5 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-deps (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Installing dbt-labs/dbt_utils
@@ -14,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-with-deps/expected-stdout
+++ b/tests/functional/run-action-with-deps/expected-stdout
@@ -15,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-expired-freshness/expected-stdout
+++ b/tests/functional/run-action-with-expired-freshness/expected-stdout
@@ -3,5 +3,4 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt source freshness"
+%AExecuting command "dbt source freshness"

--- a/tests/functional/run-action-with-expired-freshness/expected-stdout
+++ b/tests/functional/run-action-with-expired-freshness/expected-stdout
@@ -1,5 +1,7 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt source freshness"

--- a/tests/functional/run-action-with-folder/expected-stdout
+++ b/tests/functional/run-action-with-folder/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-folder/expected-stdout
+++ b/tests/functional/run-action-with-folder/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-folder (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-with-input-tables/expected-stdout
+++ b/tests/functional/run-action-with-input-tables/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-with-input-tables/expected-stdout
+++ b/tests/functional/run-action-with-input-tables/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout
+++ b/tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Stable model %s.fct_model %s [CREATE TABLE (1.0 rows, %s Bytes processed) in %ss]
 %AFinished running 2 table models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout
+++ b/tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-for-local-bigquery (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Stable model %s.fct_model %s [CREATE TABLE (1.0 rows, %s Bytes processed) in %ss]
 %AFinished running 2 table models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-with-local-bigquery/expected-stdout
+++ b/tests/functional/run-action-with-local-bigquery/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Stable model %s.fct_model %s [CREATE TABLE (1.0 rows, %s Bytes processed) in %ss]
 %AFinished running 2 table models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-local-bigquery/expected-stdout
+++ b/tests/functional/run-action-with-local-bigquery/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-for-local-bigquery (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Stable model %s.fct_model %s [CREATE TABLE (1.0 rows, %s Bytes processed) in %ss]
 %AFinished running 2 table models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-with-multiple-execute-steps/expected-stdout
+++ b/tests/functional/run-action-with-multiple-execute-steps/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 %AExecuting command "dbt build"
 Running with dbt=%A
@@ -17,7 +19,7 @@ Found 2%S
 4 of 4 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 %a
 Completed successfully%A
-Done. PASS=4 WARN=0 ERROR=0 SKIP=0%sTOTAL=4
+Done. PASS=4 WARN=0 ERROR=0 SKIP=0 %sTOTAL=4
 Executing command "dbt run"
 Running with dbt=%A
 Found 2 models%S
@@ -28,7 +30,7 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
 Executing command "dbt docs generate"
 Running with dbt=%A
 Found 2 models%S
@@ -45,7 +47,7 @@ Found 2 models%S
 2 of 2 PASS source_unique_in.c-test-bucket_test__id_ %s [PASS in %ss]
 %AFinished running 2 %a
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
 Executing command "dbt source freshness"
 Running with dbt=%A
 Found 2 models%S

--- a/tests/functional/run-action-with-multiple-execute-steps/expected-stdout
+++ b/tests/functional/run-action-with-multiple-execute-steps/expected-stdout
@@ -3,7 +3,6 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
 %AExecuting command "dbt build"
 Running with dbt=%A
 %a Starting full parse.
@@ -19,7 +18,7 @@ Found 2%S
 4 of 4 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 %a
 Completed successfully%A
-Done. PASS=4 WARN=0 ERROR=0 SKIP=0 %sTOTAL=4
+Done. PASS=4 WARN=0 ERROR=0 SKIP=0%sTOTAL=4
 Executing command "dbt run"
 Running with dbt=%A
 Found 2 models%S
@@ -30,7 +29,7 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
 Executing command "dbt docs generate"
 Running with dbt=%A
 Found 2 models%S
@@ -47,7 +46,7 @@ Found 2 models%S
 2 of 2 PASS source_unique_in.c-test-bucket_test__id_ %s [PASS in %ss]
 %AFinished running 2 %a
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
 Executing command "dbt source freshness"
 Running with dbt=%A
 Found 2 models%S

--- a/tests/functional/run-action-with-output-table-mapping/expected-stdout
+++ b/tests/functional/run-action-with-output-table-mapping/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-with-output-table-mapping/expected-stdout
+++ b/tests/functional/run-action-with-output-table-mapping/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-overriding-disallowed-params/expected-stdout
+++ b/tests/functional/run-action-with-overriding-disallowed-params/expected-stdout
@@ -1,5 +1,7 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run -t my-target --select stg_model"

--- a/tests/functional/run-action-with-overriding-disallowed-params/expected-stdout
+++ b/tests/functional/run-action-with-overriding-disallowed-params/expected-stdout
@@ -3,5 +3,4 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run -t my-target --select stg_model"
+%AExecuting command "dbt run -t my-target --select stg_model"

--- a/tests/functional/run-action-with-password/expected-stdout
+++ b/tests/functional/run-action-with-password/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-with-password/expected-stdout
+++ b/tests/functional/run-action-with-password/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-private-repository/expected-stdout
+++ b/tests/functional/run-action-with-private-repository/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project.git from branch main (d0ba82a5e1a1304f3e0802212d7c3b6633d2ab08)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action-with-private-repository/expected-stdout
+++ b/tests/functional/run-action-with-private-repository/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-with-seed-step/expected-stdout
+++ b/tests/functional/run-action-with-seed-step/expected-stdout
@@ -1,4 +1,5 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-seed (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
@@ -12,4 +13,4 @@ Found 2 models%A
 1 of 1 OK loaded seed file %s.countries %s [INSERT %s in %ss]
 %AFinished running 1 seed in 0 hours 0 minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=1 WARN=0 ERROR=0 SKIP=0%sTOTAL=1
+Done. PASS=1 WARN=0 ERROR=0 SKIP=0 %sTOTAL=1

--- a/tests/functional/run-action-with-seed-step/expected-stdout
+++ b/tests/functional/run-action-with-seed-step/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt seed"
+%AExecuting command "dbt seed"
 Running with dbt=%A
 %AStarting full parse.
 Found 2 models%A
@@ -13,4 +12,4 @@ Found 2 models%A
 1 of 1 OK loaded seed file %s.countries %s [INSERT %s in %ss]
 %AFinished running 1 seed in 0 hours 0 minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=1 WARN=0 ERROR=0 SKIP=0 %sTOTAL=1
+Done. PASS=1 WARN=0 ERROR=0 SKIP=0%sTOTAL=1

--- a/tests/functional/run-action-with-selected-models/expected-stdout
+++ b/tests/functional/run-action-with-selected-models/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run --select stg_model"
+%AExecuting command "dbt run --select stg_model"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -13,4 +12,4 @@ Found 2 models%S
 1 of 1 OK created %Sview model %s.stg_model %s [SUCCESS 1 in %ss]
 %AFinished running 1 view model in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=1 WARN=0 ERROR=0 SKIP=0 %sTOTAL=1
+Done. PASS=1 WARN=0 ERROR=0 SKIP=0%sTOTAL=1

--- a/tests/functional/run-action-with-selected-models/expected-stdout
+++ b/tests/functional/run-action-with-selected-models/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run --select stg_model"
 Running with dbt=%A
@@ -11,4 +13,4 @@ Found 2 models%S
 1 of 1 OK created %Sview model %s.stg_model %s [SUCCESS 1 in %ss]
 %AFinished running 1 view model in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=1 WARN=0 ERROR=0 SKIP=0%sTOTAL=1
+Done. PASS=1 WARN=0 ERROR=0 SKIP=0 %sTOTAL=1

--- a/tests/functional/run-action-with-selected-non-exist-models/expected-stdout
+++ b/tests/functional/run-action-with-selected-non-exist-models/expected-stdout
@@ -3,5 +3,4 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt --warn-error run --select non-existing-model"
+%AExecuting command "dbt --warn-error run --select non-existing-model"

--- a/tests/functional/run-action-with-selected-non-exist-models/expected-stdout
+++ b/tests/functional/run-action-with-selected-non-exist-models/expected-stdout
@@ -1,5 +1,7 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt --warn-error run --select non-existing-model"

--- a/tests/functional/run-action-with-show-executed-sqls/expected-stdout
+++ b/tests/functional/run-action-with-show-executed-sqls/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,7 +15,7 @@ Found 2 models%A
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
 Executed SQLs:
 %A
 create or replace   view "%s"."%s"."stg_model"%w as (     with source as (                  select * from "%s"."%s"."test"              ),          renamed as (                  select             "id",             "col2",             "col3",             "col4"         from source          )          select * from renamed   )%w;

--- a/tests/functional/run-action-with-show-executed-sqls/expected-stdout
+++ b/tests/functional/run-action-with-show-executed-sqls/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%A
@@ -15,7 +14,7 @@ Found 2 models%A
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
 Executed SQLs:
 %A
 create or replace   view "%s"."%s"."stg_model"%w as (     with source as (                  select * from "%s"."%s"."test"              ),          renamed as (                  select             "id",             "col2",             "col3",             "col4"         from source          )          select * from renamed   )%w;

--- a/tests/functional/run-action-without-generating-sources/expected-stdout
+++ b/tests/functional/run-action-without-generating-sources/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functional/run-action-without-generating-sources/expected-stdout
+++ b/tests/functional/run-action-without-generating-sources/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-sources (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action/expected-stdout
+++ b/tests/functional/run-action/expected-stdout
@@ -1,6 +1,8 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch main (%s)
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -13,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functional/run-action/expected-stdout
+++ b/tests/functional/run-action/expected-stdout
@@ -3,8 +3,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -15,4 +14,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model %s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-bigquery-dwh-with-location/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-bigquery-dwh-with-location/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-bigquery-sources (%s)
 Remote bigquery DWH: devel-249608
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Stable model %s.fct_model %s [CREATE TABLE (1.0 rows, %s Bytes processed) in %ss]
 %AFinished running 2 table models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-bigquery-dwh-with-location/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-bigquery-dwh-with-location/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Stable model %s.fct_model %s [CREATE TABLE (1.0 rows, %s Bytes processed) in %ss]
 %AFinished running 2 table models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-bigquery-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-bigquery-dwh/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-bigquery-sources (%s)
 Remote bigquery DWH: devel-249608
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Stable model %s.fct_model %s [CREATE TABLE (1.0 rows, %s Bytes processed) in %ss]
 %AFinished running 2 table models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-bigquery-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-bigquery-dwh/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Stable model %s.fct_model %s [CREATE TABLE (1.0 rows, %s Bytes processed) in %ss]
 %AFinished running 2 table models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-mssql-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-mssql-dwh/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-mssql-sources (%s)
 Remote sqlserver DWH: mssql
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model dbo.fct_model %s [OK in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-mssql-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-mssql-dwh/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model dbo.fct_model %s [OK in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-postgresql-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-postgresql-dwh/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-postgres-sources (%s)
 Remote postgres DWH: pgsql
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model public.fct_model %s [CREATE VIEW in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-postgresql-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-postgresql-dwh/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model public.fct_model %s [CREATE VIEW in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-redshift-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-redshift-dwh/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model public.fct_model %s [%s in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-redshift-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-redshift-dwh/expected-stdout
@@ -1,6 +1,6 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-redshift-sources (%s)
-Generated profiles.yml: %A
 Remote redshift DWH: testing.cx4py8yq28xb.us-east-1.redshift.amazonaws.com
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml

--- a/tests/functionalRemoteDWH/run-action-with-remote-redshift-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-redshift-dwh/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-redshift-sources (%s)
+Generated profiles.yml: %A
 Remote redshift DWH: testing.cx4py8yq28xb.us-east-1.redshift.amazonaws.com
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model public.fct_model %s [%s in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-target-and-profiles-dir/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-target-and-profiles-dir/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run --target test --profiles-dir ./config"
+%AExecuting command "dbt run --target test --profiles-dir ./config"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-target-and-profiles-dir/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-target-and-profiles-dir/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-profiles-dir (%s)
 Remote snowflake DWH: keboola.snowflakecomputing.com
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run --target test --profiles-dir ./config"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-target/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-target/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run --target test"
+%AExecuting command "dbt run --target test"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-target/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-target/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-profiles-yml (%s)
 Remote snowflake DWH: keboola.snowflakecomputing.com
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run --target test"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-with-password/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-with-password/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-sources (fe39bd0645d0578f63faeb750d74dd520a5ecadc)
 Remote snowflake DWH: keboola.snowflakecomputing.com
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-with-password/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh-with-password/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh/expected-stdout
@@ -1,7 +1,9 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-sources (fe39bd0645d0578f63faeb750d74dd520a5ecadc)
 Remote snowflake DWH: keboola.snowflakecomputing.com
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
+Warning: No packages were found in packages.yml
 Warning: No packages were found in packages.yml
 Executing command "dbt run"
 Running with dbt=%A
@@ -14,4 +16,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-dwh/expected-stdout
@@ -4,8 +4,7 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run"
+%AExecuting command "dbt run"
 Running with dbt=%A
 %s Starting full parse.
 Found 2 models%S
@@ -16,4 +15,4 @@ Found 2 models%S
 2 of 2 OK created %Sview model WORKSPACE_%s.fct_model %s [SUCCESS 1 in %ss]
 %AFinished running 2 view models in %s hours %s minutes and %s seconds (%ss).%A
 Completed successfully%A
-Done. PASS=2 WARN=0 ERROR=0 SKIP=0 %sTOTAL=2
+Done. PASS=2 WARN=0 ERROR=0 SKIP=0%sTOTAL=2

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-key-pair-failed/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-key-pair-failed/expected-stdout
@@ -1,5 +1,6 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-profiles-yml (%s)
 Remote snowflake DWH: keboola.snowflakecomputing.com
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%s
 Warning: No packages were found in packages.yml

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-key-pair-failed/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-key-pair-failed/expected-stdout
@@ -4,5 +4,4 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%s
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run --target test"
+%AExecuting command "dbt run --target test"

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-password-failed/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-password-failed/expected-stdout
@@ -4,5 +4,4 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%s
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run --target test"
+%AExecuting command "dbt run --target test"

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-password-failed/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-password-failed/expected-stdout
@@ -1,5 +1,6 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-profiles-yml-with-password (%s)
 Remote snowflake DWH: keboola.snowflakecomputing.com
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%s
 Warning: No packages were found in packages.yml

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-wrong-key-pair-failed/expected-stderr
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-wrong-key-pair-failed/expected-stderr
@@ -1,1 +1,2 @@
+dbt stderr: %A
 Encountered an error: Runtime Error   Database error while listing schemas in database ""SAPI_9317""   Database Error     250001 (08001): Failed to connect to DB: keboola.snowflakecomputing.com:443. JWT token is invalid. [%s]

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-wrong-key-pair-failed/expected-stderr
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-wrong-key-pair-failed/expected-stderr
@@ -1,2 +1,1 @@
-dbt stderr: %A
-Encountered an error: Runtime Error   Database error while listing schemas in database ""SAPI_9317""   Database Error     250001 (08001): Failed to connect to DB: keboola.snowflakecomputing.com:443. JWT token is invalid. [%s]
+%AEncountered an error: Runtime Error   Database error while listing schemas in database ""SAPI_9317""   Database Error     250001 (08001): Failed to connect to DB: keboola.snowflakecomputing.com:443. JWT token is invalid. [%s]

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-wrong-key-pair-failed/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-wrong-key-pair-failed/expected-stdout
@@ -1,5 +1,6 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-with-profiles-yml (%s)
 Remote snowflake DWH: keboola.snowflakecomputing.com
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%s
 Warning: No packages were found in packages.yml

--- a/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-wrong-key-pair-failed/expected-stdout
+++ b/tests/functionalRemoteDWH/run-action-with-remote-snowflake-with-wrong-key-pair-failed/expected-stdout
@@ -4,5 +4,4 @@ Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%s
 Warning: No packages were found in packages.yml
-Warning: No packages were found in packages.yml
-Executing command "dbt run --target test"
+%AExecuting command "dbt run --target test"

--- a/tests/phpunit/Helper/DbtDocsHelperTest.php
+++ b/tests/phpunit/Helper/DbtDocsHelperTest.php
@@ -60,6 +60,7 @@ class DbtDocsHelperTest extends TestCase
         $manifestJson = (string) file_get_contents(__DIR__ . '/../data/target/manifest.json');
         $runResultsJson = (string) file_get_contents(__DIR__ . '/../data/target/run_results.json');
 
+        /** @var array<string, mixed> $manifest */
         $manifest = (array) json_decode($manifestJson, true, 512, JSON_THROW_ON_ERROR);
         /** @var array<string, array<string, mixed>> $runResults */
         $runResults = (array) json_decode($runResultsJson, true, 512, JSON_THROW_ON_ERROR);

--- a/tests/phpunit/Helper/ProfilesHelperTest.php
+++ b/tests/phpunit/Helper/ProfilesHelperTest.php
@@ -29,7 +29,7 @@ class ProfilesHelperTest extends TestCase
             ],
         ];
 
-        /** @var array<string, array<string, array<string, array<string, mixed>>>> $masked */
+        /** @var array<string, mixed> $masked */
         $masked = ProfilesHelper::maskSensitiveValues($data);
 
         self::assertSame('****', $masked['default']['outputs']['kbc_prod']['password']);
@@ -49,7 +49,7 @@ class ProfilesHelperTest extends TestCase
             ],
         ];
 
-        /** @var array<string, array<string, array<string, mixed>>> $masked */
+        /** @var array<string, mixed> $masked */
         $masked = ProfilesHelper::maskSensitiveValues($data);
 
         self::assertSame('****', $masked['outputs']['kbc_prod']['private_key']);
@@ -60,10 +60,13 @@ class ProfilesHelperTest extends TestCase
         $data = [
             'password' => 'secret1',
             'private_key' => 'secret2',
-            'keyfile' => 'secret3',
-            'key_content' => 'secret4',
-            'token' => 'secret5',
-            'client_secret' => 'secret6',
+            'private_key_passphrase' => 'secret3',
+            'keyfile' => 'secret4',
+            'keyfile_json' => 'secret5',
+            'key_content' => 'secret6',
+            'token' => 'secret7',
+            'secret' => 'secret8',
+            'client_secret' => 'secret9',
             'account' => 'not-secret',
         ];
 
@@ -71,9 +74,12 @@ class ProfilesHelperTest extends TestCase
 
         self::assertSame('****', $masked['password']);
         self::assertSame('****', $masked['private_key']);
+        self::assertSame('****', $masked['private_key_passphrase']);
         self::assertSame('****', $masked['keyfile']);
+        self::assertSame('****', $masked['keyfile_json']);
         self::assertSame('****', $masked['key_content']);
         self::assertSame('****', $masked['token']);
+        self::assertSame('****', $masked['secret']);
         self::assertSame('****', $masked['client_secret']);
         self::assertSame('not-secret', $masked['account']);
     }
@@ -95,7 +101,7 @@ class ProfilesHelperTest extends TestCase
             ],
         ];
 
-        /** @var array<string, array<string, array<string, mixed>>> $masked */
+        /** @var array<string, mixed> $masked */
         $masked = ProfilesHelper::maskSensitiveValues($data);
 
         self::assertSame('****', $masked['outputs']['prod']['password']);
@@ -161,7 +167,7 @@ class ProfilesHelperTest extends TestCase
             ],
         ];
 
-        /** @var array<string, array<string, array<string, mixed>>> $resolved */
+        /** @var array<string, mixed> $resolved */
         $resolved = ProfilesHelper::resolveEnvVars($data);
 
         self::assertSame('snowflake', $resolved['outputs']['kbc_prod']['type']);
@@ -211,6 +217,21 @@ class ProfilesHelperTest extends TestCase
         self::assertFalse($resolved['trust_cert']);
 
         putenv('DBT_KBC_PROD_TRUST_CERT');
+    }
+
+    public function testAsNumberWithFloatValue(): void
+    {
+        putenv('DBT_KBC_PROD_TIMEOUT=4.5');
+
+        $data = [
+            'timeout' => '{{ env_var("DBT_KBC_PROD_TIMEOUT")| as_number }}',
+        ];
+
+        $resolved = ProfilesHelper::resolveEnvVars($data);
+
+        self::assertSame(4.5, $resolved['timeout']);
+
+        putenv('DBT_KBC_PROD_TIMEOUT');
     }
 
     public function testAsNumberWithNonNumericValueReturnsRawString(): void

--- a/tests/phpunit/Helper/ProfilesHelperTest.php
+++ b/tests/phpunit/Helper/ProfilesHelperTest.php
@@ -183,6 +183,51 @@ class ProfilesHelperTest extends TestCase
         self::assertSame('{{ env_var("DBT_NONEXISTENT_VAR") }}', $resolved['type']);
     }
 
+    public function testResolvesAsBoolFilter(): void
+    {
+        putenv('DBT_KBC_PROD_TRUST_CERT=true');
+
+        $data = [
+            'trust_cert' => '{{ env_var("DBT_KBC_PROD_TRUST_CERT")| as_bool }}',
+        ];
+
+        $resolved = ProfilesHelper::resolveEnvVars($data);
+
+        self::assertTrue($resolved['trust_cert']);
+
+        putenv('DBT_KBC_PROD_TRUST_CERT');
+    }
+
+    public function testResolvesAsBoolFilterFalse(): void
+    {
+        putenv('DBT_KBC_PROD_TRUST_CERT=false');
+
+        $data = [
+            'trust_cert' => '{{ env_var("DBT_KBC_PROD_TRUST_CERT")| as_bool }}',
+        ];
+
+        $resolved = ProfilesHelper::resolveEnvVars($data);
+
+        self::assertFalse($resolved['trust_cert']);
+
+        putenv('DBT_KBC_PROD_TRUST_CERT');
+    }
+
+    public function testAsNumberWithNonNumericValueReturnsRawString(): void
+    {
+        putenv('DBT_KBC_PROD_THREADS=abc');
+
+        $data = [
+            'threads' => '{{ env_var("DBT_KBC_PROD_THREADS")| as_number }}',
+        ];
+
+        $resolved = ProfilesHelper::resolveEnvVars($data);
+
+        self::assertSame('abc', $resolved['threads']);
+
+        putenv('DBT_KBC_PROD_THREADS');
+    }
+
     public function testResolveAndMaskCombined(): void
     {
         putenv('DBT_KBC_PROD_TYPE=snowflake');

--- a/tests/phpunit/Helper/ProfilesHelperTest.php
+++ b/tests/phpunit/Helper/ProfilesHelperTest.php
@@ -29,7 +29,7 @@ class ProfilesHelperTest extends TestCase
             ],
         ];
 
-        /** @var array<string, mixed> $masked */
+        /** @var array{config: array<string, mixed>, default: array{outputs: array{kbc_prod: array<string, mixed>}}} $masked */
         $masked = ProfilesHelper::maskSensitiveValues($data);
 
         self::assertSame('****', $masked['default']['outputs']['kbc_prod']['password']);
@@ -49,7 +49,7 @@ class ProfilesHelperTest extends TestCase
             ],
         ];
 
-        /** @var array<string, mixed> $masked */
+        /** @var array{outputs: array{kbc_prod: array<string, mixed>}} $masked */
         $masked = ProfilesHelper::maskSensitiveValues($data);
 
         self::assertSame('****', $masked['outputs']['kbc_prod']['private_key']);
@@ -101,7 +101,7 @@ class ProfilesHelperTest extends TestCase
             ],
         ];
 
-        /** @var array<string, mixed> $masked */
+        /** @var array{outputs: array{prod: array<string, mixed>, dev: array<string, mixed>}} $masked */
         $masked = ProfilesHelper::maskSensitiveValues($data);
 
         self::assertSame('****', $masked['outputs']['prod']['password']);
@@ -167,7 +167,7 @@ class ProfilesHelperTest extends TestCase
             ],
         ];
 
-        /** @var array<string, mixed> $resolved */
+        /** @var array{outputs: array{kbc_prod: array<string, mixed>}} $resolved */
         $resolved = ProfilesHelper::resolveEnvVars($data);
 
         self::assertSame('snowflake', $resolved['outputs']['kbc_prod']['type']);

--- a/tests/phpunit/Helper/ProfilesHelperTest.php
+++ b/tests/phpunit/Helper/ProfilesHelperTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DbtTransformation\Tests\Helper;
+
+use DbtTransformation\Helper\ProfilesHelper;
+use PHPUnit\Framework\TestCase;
+
+class ProfilesHelperTest extends TestCase
+{
+    public function testMasksSensitiveKeys(): void
+    {
+        $data = [
+            'config' => ['send_anonymous_usage_stats' => false],
+            'default' => [
+                'target' => 'dev',
+                'outputs' => [
+                    'kbc_prod' => [
+                        'type' => 'snowflake',
+                        'account' => 'my-account',
+                        'user' => 'my-user',
+                        'password' => 'super-secret-password',
+                        'database' => 'my-db',
+                        'schema' => 'my-schema',
+                        'warehouse' => 'my-wh',
+                    ],
+                ],
+            ],
+        ];
+
+        /** @var array<string, array<string, array<string, array<string, mixed>>>> $masked */
+        $masked = ProfilesHelper::maskSensitiveValues($data);
+
+        self::assertSame('****', $masked['default']['outputs']['kbc_prod']['password']);
+        self::assertSame('my-account', $masked['default']['outputs']['kbc_prod']['account']);
+        self::assertSame('my-user', $masked['default']['outputs']['kbc_prod']['user']);
+        self::assertSame('my-db', $masked['default']['outputs']['kbc_prod']['database']);
+    }
+
+    public function testMasksPrivateKey(): void
+    {
+        $data = [
+            'outputs' => [
+                'kbc_prod' => [
+                    'type' => 'snowflake',
+                    'private_key' => '-----BEGIN PRIVATE KEY-----\nMIIE...',
+                ],
+            ],
+        ];
+
+        /** @var array<string, array<string, array<string, mixed>>> $masked */
+        $masked = ProfilesHelper::maskSensitiveValues($data);
+
+        self::assertSame('****', $masked['outputs']['kbc_prod']['private_key']);
+    }
+
+    public function testMasksAllSensitiveKeys(): void
+    {
+        $data = [
+            'password' => 'secret1',
+            'private_key' => 'secret2',
+            'keyfile' => 'secret3',
+            'key_content' => 'secret4',
+            'token' => 'secret5',
+            'client_secret' => 'secret6',
+            'account' => 'not-secret',
+        ];
+
+        $masked = ProfilesHelper::maskSensitiveValues($data);
+
+        self::assertSame('****', $masked['password']);
+        self::assertSame('****', $masked['private_key']);
+        self::assertSame('****', $masked['keyfile']);
+        self::assertSame('****', $masked['key_content']);
+        self::assertSame('****', $masked['token']);
+        self::assertSame('****', $masked['client_secret']);
+        self::assertSame('not-secret', $masked['account']);
+    }
+
+    public function testMasksMultipleOutputs(): void
+    {
+        $data = [
+            'outputs' => [
+                'prod' => [
+                    'type' => 'snowflake',
+                    'password' => 'secret-prod',
+                    'account' => 'prod-account',
+                ],
+                'dev' => [
+                    'type' => 'snowflake',
+                    'private_key' => 'secret-dev',
+                    'account' => 'dev-account',
+                ],
+            ],
+        ];
+
+        /** @var array<string, array<string, array<string, mixed>>> $masked */
+        $masked = ProfilesHelper::maskSensitiveValues($data);
+
+        self::assertSame('****', $masked['outputs']['prod']['password']);
+        self::assertSame('prod-account', $masked['outputs']['prod']['account']);
+        self::assertSame('****', $masked['outputs']['dev']['private_key']);
+        self::assertSame('dev-account', $masked['outputs']['dev']['account']);
+    }
+
+    public function testPreservesNonSensitiveValues(): void
+    {
+        $data = [
+            'type' => 'snowflake',
+            'account' => 'my-account',
+            'insecure_mode' => true,
+            'threads' => 4,
+        ];
+
+        $masked = ProfilesHelper::maskSensitiveValues($data);
+
+        self::assertSame($data, $masked);
+    }
+
+    public function testHandlesEmptyArray(): void
+    {
+        self::assertSame([], ProfilesHelper::maskSensitiveValues([]));
+    }
+
+    public function testResolvesEnvVars(): void
+    {
+        putenv('DBT_KBC_PROD_TYPE=snowflake');
+        putenv('DBT_KBC_PROD_ACCOUNT=my-account');
+        putenv('DBT_KBC_PROD_THREADS=4');
+
+        $data = [
+            'type' => '{{ env_var("DBT_KBC_PROD_TYPE") }}',
+            'account' => '{{ env_var("DBT_KBC_PROD_ACCOUNT") }}',
+            'threads' => '{{ env_var("DBT_KBC_PROD_THREADS")| as_number }}',
+        ];
+
+        $resolved = ProfilesHelper::resolveEnvVars($data);
+
+        self::assertSame('snowflake', $resolved['type']);
+        self::assertSame('my-account', $resolved['account']);
+        self::assertSame(4, $resolved['threads']);
+
+        putenv('DBT_KBC_PROD_TYPE');
+        putenv('DBT_KBC_PROD_ACCOUNT');
+        putenv('DBT_KBC_PROD_THREADS');
+    }
+
+    public function testResolvesNestedEnvVars(): void
+    {
+        putenv('DBT_KBC_PROD_TYPE=snowflake');
+        putenv('DBT_KBC_PROD_PASSWORD=secret');
+
+        $data = [
+            'outputs' => [
+                'kbc_prod' => [
+                    'type' => '{{ env_var("DBT_KBC_PROD_TYPE") }}',
+                    'password' => '{{ env_var("DBT_KBC_PROD_PASSWORD") }}',
+                    'insecure_mode' => true,
+                ],
+            ],
+        ];
+
+        /** @var array<string, array<string, array<string, mixed>>> $resolved */
+        $resolved = ProfilesHelper::resolveEnvVars($data);
+
+        self::assertSame('snowflake', $resolved['outputs']['kbc_prod']['type']);
+        self::assertSame('secret', $resolved['outputs']['kbc_prod']['password']);
+        self::assertTrue($resolved['outputs']['kbc_prod']['insecure_mode']);
+
+        putenv('DBT_KBC_PROD_TYPE');
+        putenv('DBT_KBC_PROD_PASSWORD');
+    }
+
+    public function testKeepsUnresolvableEnvVars(): void
+    {
+        $data = [
+            'type' => '{{ env_var("DBT_NONEXISTENT_VAR") }}',
+        ];
+
+        $resolved = ProfilesHelper::resolveEnvVars($data);
+
+        self::assertSame('{{ env_var("DBT_NONEXISTENT_VAR") }}', $resolved['type']);
+    }
+
+    public function testResolveAndMaskCombined(): void
+    {
+        putenv('DBT_KBC_PROD_TYPE=snowflake');
+        putenv('DBT_KBC_PROD_ACCOUNT=my-account');
+        putenv('DBT_KBC_PROD_PASSWORD=super-secret');
+
+        $data = [
+            'type' => '{{ env_var("DBT_KBC_PROD_TYPE") }}',
+            'account' => '{{ env_var("DBT_KBC_PROD_ACCOUNT") }}',
+            'password' => '{{ env_var("DBT_KBC_PROD_PASSWORD") }}',
+        ];
+
+        $resolved = ProfilesHelper::resolveEnvVars($data);
+        $masked = ProfilesHelper::maskSensitiveValues($resolved);
+
+        self::assertSame('snowflake', $masked['type']);
+        self::assertSame('my-account', $masked['account']);
+        self::assertSame('****', $masked['password']);
+
+        putenv('DBT_KBC_PROD_TYPE');
+        putenv('DBT_KBC_PROD_ACCOUNT');
+        putenv('DBT_KBC_PROD_PASSWORD');
+    }
+}

--- a/tests/phpunit/Service/DbtLogServiceTest.php
+++ b/tests/phpunit/Service/DbtLogServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DbtTransformation\Tests\Service;
+
+use ColinODell\PsrTestLogger\TestLogger;
+use DbtTransformation\Service\DbtLogService;
+use PHPUnit\Framework\TestCase;
+
+class DbtLogServiceTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/dbt-log-service-test-' . uniqid();
+        mkdir($this->tmpDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $files = glob($this->tmpDir . '/*');
+        if ($files !== false) {
+            array_map('unlink', $files);
+        }
+        rmdir($this->tmpDir);
+    }
+
+    public function testReadsAllLines(): void
+    {
+        $logFile = $this->tmpDir . '/dbt.log';
+        $content = '{"level":"info","msg":"Starting"}' . "\n"
+            . '{"level":"info","msg":"Done"}' . "\n";
+        file_put_contents($logFile, $content);
+
+        $logger = new TestLogger();
+        $service = new DbtLogService($logger, $logFile);
+        $service->log();
+
+        self::assertTrue($logger->hasInfoThatContains('{"level":"info","msg":"Starting"}'));
+        self::assertTrue($logger->hasInfoThatContains('{"level":"info","msg":"Done"}'));
+    }
+
+    public function testIncrementalReads(): void
+    {
+        $logFile = $this->tmpDir . '/dbt.log';
+        file_put_contents($logFile, '{"level":"info","msg":"Step 1"}' . "\n");
+
+        $logger = new TestLogger();
+        $service = new DbtLogService($logger, $logFile);
+        $service->log();
+
+        self::assertCount(1, $logger->records);
+        self::assertTrue($logger->hasInfoThatContains('Step 1'));
+
+        // Append more lines
+        file_put_contents($logFile, '{"level":"info","msg":"Step 2"}' . "\n", FILE_APPEND);
+        $service->log();
+
+        self::assertCount(2, $logger->records);
+        self::assertTrue($logger->hasInfoThatContains('Step 2'));
+    }
+
+    public function testMissingFile(): void
+    {
+        $logger = new TestLogger();
+        $service = new DbtLogService($logger, $this->tmpDir . '/nonexistent.log');
+        $service->log();
+
+        self::assertEmpty($logger->records);
+    }
+
+    public function testEmptyFile(): void
+    {
+        $logFile = $this->tmpDir . '/dbt.log';
+        file_put_contents($logFile, '');
+
+        $logger = new TestLogger();
+        $service = new DbtLogService($logger, $logFile);
+        $service->log();
+
+        self::assertEmpty($logger->records);
+    }
+
+    public function testMultiStepSimulation(): void
+    {
+        $logFile = $this->tmpDir . '/dbt.log';
+        $logger = new TestLogger();
+        $service = new DbtLogService($logger, $logFile);
+
+        // Step 1: dbt deps
+        file_put_contents($logFile, '{"level":"info","msg":"Installing deps"}' . "\n");
+        $service->log();
+        self::assertCount(1, $logger->records);
+
+        // Step 2: dbt run
+        file_put_contents($logFile, '{"level":"info","msg":"Running models"}' . "\n", FILE_APPEND);
+        $service->log();
+        self::assertCount(2, $logger->records);
+
+        // Step 3: dbt test
+        file_put_contents($logFile, '{"level":"info","msg":"Running tests"}' . "\n", FILE_APPEND);
+        $service->log();
+        self::assertCount(3, $logger->records);
+    }
+
+    public function testFileTruncation(): void
+    {
+        $logFile = $this->tmpDir . '/dbt.log';
+        file_put_contents($logFile, '{"level":"info","msg":"Old content that is long enough"}' . "\n");
+
+        $logger = new TestLogger();
+        $service = new DbtLogService($logger, $logFile);
+        $service->log();
+
+        self::assertCount(1, $logger->records);
+
+        // Truncate and write shorter content
+        file_put_contents($logFile, '{"level":"info","msg":"New"}' . "\n");
+        $service->log();
+
+        self::assertCount(2, $logger->records);
+        self::assertTrue($logger->hasInfoThatContains('New'));
+    }
+
+    public function testSkipsEmptyLines(): void
+    {
+        $logFile = $this->tmpDir . '/dbt.log';
+        $content = '{"level":"info","msg":"Line 1"}' . "\n\n\n"
+            . '{"level":"info","msg":"Line 2"}' . "\n";
+        file_put_contents($logFile, $content);
+
+        $logger = new TestLogger();
+        $service = new DbtLogService($logger, $logFile);
+        $service->log();
+
+        self::assertCount(2, $logger->records);
+    }
+}


### PR DESCRIPTION
## Description

Add comprehensive dbt logging improvements to aid debugging and operational visibility:

- **Profiles logging**: Log generated `profiles.yml` with sensitive values (`password`, `token`, `private_key`, `private_key_passphrase`) masked and `env_var` references resolved to actual values. Implemented in new `ProfilesHelper` class.
- **Incremental dbt.log reading**: New `DbtLogService` reads `dbt.log` incrementally (tracking file offset) and outputs contents in debug mode (`KBC_COMPONENT_RUN_MODE=debug`), replacing the old `showDbtLog` config option.
- **Stderr on failure**: Log dbt stderr output when a dbt command fails, improving error visibility.
- **PHPStan upgrade**: Upgraded to phpstan ^1.12 and resolved all new errors.
- **dbt 1.8.6 compatibility**: Updated expected test outputs for compatibility with dbt 1.8.6.

## Release Notes

- **Justification**
    - Debugging dbt transformation failures currently requires manual inspection. This change surfaces key diagnostic information (profiles config, dbt logs, stderr) directly in the component output.
    - Adds logging of the dbt configuration and runtime logs to help users and support troubleshoot transformation issues more easily.
- **Plans for Customer Communication**
    - The `showDbtLog` config option is replaced by `KBC_COMPONENT_RUN_MODE=debug` environment variable. Existing users of `showDbtLog` will need to switch. No other customer communication needed.
- **Impact Analysis**
    - Low risk. Logging is additive — no changes to dbt execution logic. Sensitive values in profiles are masked before output.
    - Not behind a feature flag. Debug log output is gated by `KBC_COMPONENT_RUN_MODE=debug`.
- **Deployment Plan**
    - Continuous deployment.
- **Rollback Plan**
    - Standard revert/redeploy. No one-way door changes.
- **Post-Release Support Plan**
    - No special post-release monitoring needed. Support team does not need to be notified.

## Test plan
- [x] Unit tests pass for `DbtLogServiceTest` and `ProfilesHelperTest`
- [x] Functional datadir tests pass with updated expected-stdout files
- [x] Verify profiles.yml logging masks sensitive values (passwords, keys, tokens)
- [x] Verify debug mode dbt.log output works with `KBC_COMPONENT_RUN_MODE=debug`

🤖 Generated with [Claude Code](https://claude.com/claude-code)