### PR TITLE
feat: AJDA-2149 add ocsp fail open to true for remote snowflake

### DIFF
--- a/src/DwhProvider/RemoteSnowflakeProvider.php
+++ b/src/DwhProvider/RemoteSnowflakeProvider.php
@@ -22,7 +22,7 @@ class RemoteSnowflakeProvider extends RemoteProvider implements DwhProviderInter
             $this->projectPath,
             $profilesPath,
             $this->getOutputs($configurationNames, $this->getDbtParams(), $this->projectIds),
-            true,
+            ['ocsp_fail_open' => true],
         );
 
         $this->logger->info($this->getConnectionLogMessage());

--- a/src/DwhProvider/RemoteSnowflakeProvider.php
+++ b/src/DwhProvider/RemoteSnowflakeProvider.php
@@ -10,6 +10,24 @@ class RemoteSnowflakeProvider extends RemoteProvider implements DwhProviderInter
 {
     public const DWH_PROVIDER_TYPE = 'snowflake';
 
+    /**
+     * @param array<int, string> $configurationNames
+     * @throws \Keboola\Component\UserException
+     */
+    public function createDbtYamlFiles(string $profilesPath, array $configurationNames = []): void
+    {
+        $this->setEnvVars();
+
+        $this->createProfilesFileService->dumpYaml(
+            $this->projectPath,
+            $profilesPath,
+            $this->getOutputs($configurationNames, $this->getDbtParams(), $this->projectIds),
+            true,
+        );
+
+        $this->logger->info($this->getConnectionLogMessage());
+    }
+
     public function setEnvVars(): void
     {
         $workspace = $this->config->getRemoteDwh();

--- a/src/DwhProvider/RemoteSnowflakeProvider.php
+++ b/src/DwhProvider/RemoteSnowflakeProvider.php
@@ -22,7 +22,7 @@ class RemoteSnowflakeProvider extends RemoteProvider implements DwhProviderInter
             $this->projectPath,
             $profilesPath,
             $this->getOutputs($configurationNames, $this->getDbtParams(), $this->projectIds),
-            ['ocsp_fail_open' => true],
+            ['insecure_mode' => true],
         );
 
         $this->logger->info($this->getConnectionLogMessage());

--- a/src/FileDumper/DbtProfilesYaml.php
+++ b/src/FileDumper/DbtProfilesYaml.php
@@ -11,13 +11,14 @@ class DbtProfilesYaml extends FilesystemAwareDumper
 {
     /**
      * @param array<string, array<string, string|bool>> $outputs
+     * @param array<string, string|bool|int|float> $additionalOptions
      * @throws UserException
      */
     public function dumpYaml(
         string $projectPath,
         string $profilesPath,
         array $outputs,
-        bool $addOcspFailOpen = false,
+        array $additionalOptions = [],
     ): void {
         $dbtProjectYamlPath = sprintf('%s/dbt_project.yml', $projectPath);
         if (!$this->filesystem->exists($dbtProjectYamlPath)) {
@@ -38,15 +39,17 @@ class DbtProfilesYaml extends FilesystemAwareDumper
             }
         }
 
-        if ($addOcspFailOpen) {
+        if ($additionalOptions !== []) {
             foreach ($outputs as $outputName => $outputConfig) {
                 if (!is_array($outputConfig)) {
                     continue;
                 }
-                if (!array_key_exists('ocsp_fail_open', $outputConfig)) {
-                    $outputConfig['ocsp_fail_open'] = true;
-                    $outputs[$outputName] = $outputConfig;
+                foreach ($additionalOptions as $optionName => $optionValue) {
+                    if (!array_key_exists($optionName, $outputConfig)) {
+                        $outputConfig[$optionName] = $optionValue;
+                    }
                 }
+                $outputs[$outputName] = $outputConfig;
             }
         }
 

--- a/tests/phpunit/Service/DbtYamlCreateService/DbtYamlCreateTest.php
+++ b/tests/phpunit/Service/DbtYamlCreateService/DbtYamlCreateTest.php
@@ -140,11 +140,46 @@ class DbtYamlCreateTest extends TestCase
                 [],
                 RemoteSnowflakeProvider::getDbtParams(),
             ),
-            true,
+            ['ocsp_fail_open' => true],
         );
 
         self::assertFileEquals(
             sprintf('%s/expectedRemoteSnowflakeProfiles.yml', $this->providerDataDir),
+            sprintf('%s/profiles.yml', $this->dataDir),
+        );
+
+        putenv('DBT_KBC_PROD_PRIVATE_KEY');
+    }
+
+    /**
+     * @throws \Keboola\Component\UserException
+     */
+    public function testCreateProfileYamlWithRemoteSnowflakeAdditionalOptions(): void
+    {
+        putenv('DBT_KBC_PROD_PRIVATE_KEY=private_key');
+
+        $fs = new Filesystem();
+        $fs->copy(
+            sprintf('%s/dbt_project.yml', $this->providerDataDir),
+            sprintf('%s/dbt_project.yml', $this->dataDir),
+        );
+
+        $service = new DbtProfilesYaml();
+        $service->dumpYaml(
+            $this->dataDir,
+            $this->dataDir,
+            RemoteSnowflakeProvider::getOutputs(
+                [],
+                RemoteSnowflakeProvider::getDbtParams(),
+            ),
+            [
+                'ocsp_fail_open' => true,
+                'foo' => 'bar',
+            ],
+        );
+
+        self::assertFileEquals(
+            sprintf('%s/expectedRemoteSnowflakeProfilesWithAdditionalOptions.yml', $this->providerDataDir),
             sprintf('%s/profiles.yml', $this->dataDir),
         );
 
@@ -177,7 +212,7 @@ class DbtYamlCreateTest extends TestCase
                 [],
                 RemoteSnowflakeProvider::getDbtParams(),
             ),
-            true,
+            ['ocsp_fail_open' => true],
         );
 
         self::assertFileEquals(

--- a/tests/phpunit/Service/DbtYamlCreateService/DbtYamlCreateTest.php
+++ b/tests/phpunit/Service/DbtYamlCreateService/DbtYamlCreateTest.php
@@ -122,7 +122,7 @@ class DbtYamlCreateTest extends TestCase
     /**
      * @throws \Keboola\Component\UserException
      */
-    public function testCreateProfileYamlWithRemoteSnowflakeAddsOcspFailOpen(): void
+    public function testCreateProfileYamlWithRemoteSnowflakeAddsInsecureMode(): void
     {
         putenv('DBT_KBC_PROD_PRIVATE_KEY=private_key');
 
@@ -140,7 +140,7 @@ class DbtYamlCreateTest extends TestCase
                 [],
                 RemoteSnowflakeProvider::getDbtParams(),
             ),
-            ['ocsp_fail_open' => true],
+            ['insecure_mode' => true],
         );
 
         self::assertFileEquals(
@@ -173,7 +173,7 @@ class DbtYamlCreateTest extends TestCase
                 RemoteSnowflakeProvider::getDbtParams(),
             ),
             [
-                'ocsp_fail_open' => true,
+                'insecure_mode' => true,
                 'foo' => 'bar',
             ],
         );
@@ -189,7 +189,7 @@ class DbtYamlCreateTest extends TestCase
     /**
      * @throws \Keboola\Component\UserException
      */
-    public function testMergeProfilesYamlWithRemoteSnowflakeAddsOcspFailOpen(): void
+    public function testMergeProfilesYamlWithRemoteSnowflakeAddsInsecureMode(): void
     {
         putenv('DBT_KBC_PROD_PRIVATE_KEY=private_key');
 
@@ -212,7 +212,7 @@ class DbtYamlCreateTest extends TestCase
                 [],
                 RemoteSnowflakeProvider::getDbtParams(),
             ),
-            ['ocsp_fail_open' => true],
+            ['insecure_mode' => true],
         );
 
         self::assertFileEquals(

--- a/tests/phpunit/data/expectedRemoteSnowflakeProfiles.yml
+++ b/tests/phpunit/data/expectedRemoteSnowflakeProfiles.yml
@@ -1,0 +1,15 @@
+config:
+    send_anonymous_usage_stats: false
+default:
+    target: dev
+    outputs:
+        kbc_prod:
+            type: '{{ env_var("DBT_KBC_PROD_TYPE") }}'
+            user: '{{ env_var("DBT_KBC_PROD_USER") }}'
+            schema: '{{ env_var("DBT_KBC_PROD_SCHEMA") }}'
+            warehouse: '{{ env_var("DBT_KBC_PROD_WAREHOUSE") }}'
+            database: '{{ env_var("DBT_KBC_PROD_DATABASE") }}'
+            account: '{{ env_var("DBT_KBC_PROD_ACCOUNT") }}'
+            threads: '{{ env_var("DBT_KBC_PROD_THREADS")| as_number }}'
+            private_key: '{{ env_var("DBT_KBC_PROD_PRIVATE_KEY") }}'
+            ocsp_fail_open: true

--- a/tests/phpunit/data/expectedRemoteSnowflakeProfiles.yml
+++ b/tests/phpunit/data/expectedRemoteSnowflakeProfiles.yml
@@ -12,4 +12,4 @@ default:
             account: '{{ env_var("DBT_KBC_PROD_ACCOUNT") }}'
             threads: '{{ env_var("DBT_KBC_PROD_THREADS")| as_number }}'
             private_key: '{{ env_var("DBT_KBC_PROD_PRIVATE_KEY") }}'
-            ocsp_fail_open: true
+            insecure_mode: true

--- a/tests/phpunit/data/expectedRemoteSnowflakeProfilesMerged.yml
+++ b/tests/phpunit/data/expectedRemoteSnowflakeProfilesMerged.yml
@@ -1,0 +1,25 @@
+config:
+    send_anonymous_usage_stats: false
+default:
+    target: dev
+    outputs:
+        prod:
+            type: postgres
+            host: prod-db.example.com
+            port: 5432
+            user: prod_user
+            password: prod_password
+            dbname: prod_database
+            schema: prod_schema
+            threads: 8
+            ocsp_fail_open: true
+        kbc_prod:
+            type: '{{ env_var("DBT_KBC_PROD_TYPE") }}'
+            user: '{{ env_var("DBT_KBC_PROD_USER") }}'
+            schema: '{{ env_var("DBT_KBC_PROD_SCHEMA") }}'
+            warehouse: '{{ env_var("DBT_KBC_PROD_WAREHOUSE") }}'
+            database: '{{ env_var("DBT_KBC_PROD_DATABASE") }}'
+            account: '{{ env_var("DBT_KBC_PROD_ACCOUNT") }}'
+            threads: '{{ env_var("DBT_KBC_PROD_THREADS")| as_number }}'
+            private_key: '{{ env_var("DBT_KBC_PROD_PRIVATE_KEY") }}'
+            ocsp_fail_open: true

--- a/tests/phpunit/data/expectedRemoteSnowflakeProfilesMerged.yml
+++ b/tests/phpunit/data/expectedRemoteSnowflakeProfilesMerged.yml
@@ -12,7 +12,7 @@ default:
             dbname: prod_database
             schema: prod_schema
             threads: 8
-            ocsp_fail_open: true
+            insecure_mode: true
         kbc_prod:
             type: '{{ env_var("DBT_KBC_PROD_TYPE") }}'
             user: '{{ env_var("DBT_KBC_PROD_USER") }}'
@@ -22,4 +22,4 @@ default:
             account: '{{ env_var("DBT_KBC_PROD_ACCOUNT") }}'
             threads: '{{ env_var("DBT_KBC_PROD_THREADS")| as_number }}'
             private_key: '{{ env_var("DBT_KBC_PROD_PRIVATE_KEY") }}'
-            ocsp_fail_open: true
+            insecure_mode: true

--- a/tests/phpunit/data/expectedRemoteSnowflakeProfilesWithAdditionalOptions.yml
+++ b/tests/phpunit/data/expectedRemoteSnowflakeProfilesWithAdditionalOptions.yml
@@ -1,0 +1,16 @@
+config:
+    send_anonymous_usage_stats: false
+default:
+    target: dev
+    outputs:
+        kbc_prod:
+            type: '{{ env_var("DBT_KBC_PROD_TYPE") }}'
+            user: '{{ env_var("DBT_KBC_PROD_USER") }}'
+            schema: '{{ env_var("DBT_KBC_PROD_SCHEMA") }}'
+            warehouse: '{{ env_var("DBT_KBC_PROD_WAREHOUSE") }}'
+            database: '{{ env_var("DBT_KBC_PROD_DATABASE") }}'
+            account: '{{ env_var("DBT_KBC_PROD_ACCOUNT") }}'
+            threads: '{{ env_var("DBT_KBC_PROD_THREADS")| as_number }}'
+            private_key: '{{ env_var("DBT_KBC_PROD_PRIVATE_KEY") }}'
+            ocsp_fail_open: true
+            foo: bar

--- a/tests/phpunit/data/expectedRemoteSnowflakeProfilesWithAdditionalOptions.yml
+++ b/tests/phpunit/data/expectedRemoteSnowflakeProfilesWithAdditionalOptions.yml
@@ -12,5 +12,5 @@ default:
             account: '{{ env_var("DBT_KBC_PROD_ACCOUNT") }}'
             threads: '{{ env_var("DBT_KBC_PROD_THREADS")| as_number }}'
             private_key: '{{ env_var("DBT_KBC_PROD_PRIVATE_KEY") }}'
-            ocsp_fail_open: true
+            insecure_mode: true
             foo: bar


### PR DESCRIPTION
## Summary
- Add an optional `ocsp_fail_open` injection when generating `profiles.yml` outputs.
- Always enable this flag for remote Snowflake profiles during dbt YAML creation.
- Extend tests and fixtures for remote Snowflake profile generation and merge scenarios.

## Why
- Fixes connection issues to Snowflake over Private Link from a closed environment by explicitly setting `ocsp_fail_open`.

## Tests
- Added/updated unit tests in `tests/phpunit/Service/DbtYamlCreateService/DbtYamlCreateTest.php`.
- New fixtures: `tests/phpunit/data/expectedRemoteSnowflakeProfiles.yml`, `tests/phpunit/data/expectedRemoteSnowflakeProfilesMerged.yml`.

## Ticket
https://linear.app/keboola/issue/AJDA-2149/dbt-core-problem-with-database-connection