### PR TITLE
feat: add pre-flight check for BigQuery workspace dataset accessibility

### DIFF
--- a/src/DwhProvider/LocalBigQueryProvider.php
+++ b/src/DwhProvider/LocalBigQueryProvider.php
@@ -14,6 +14,9 @@ use Keboola\Component\UserException;
 use Keboola\StorageApi\Client;
 use Keboola\Temp\Temp;
 use Psr\Log\LoggerInterface;
+use Retry\BackOff\FixedBackOffPolicy;
+use Retry\Policy\SimpleRetryPolicy;
+use Retry\RetryProxy;
 use RuntimeException;
 
 class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
@@ -42,8 +45,8 @@ class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
         $this->temp = new Temp('dbt-big-query-local');
     }
 
-    private const DATASET_CHECK_MAX_RETRIES = 10;
-    private const DATASET_CHECK_RETRY_DELAY_SECONDS = 3;
+    private const DATASET_CHECK_MAX_ATTEMPTS = 10;
+    private const DATASET_CHECK_RETRY_DELAY_MS = 3000;
 
     /**
      * @param array<int, string> $configurationNames
@@ -108,37 +111,27 @@ class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
 
         $dataset = $bqClient->dataset($datasetName);
 
-        for ($attempt = 1; $attempt <= self::DATASET_CHECK_MAX_RETRIES; $attempt++) {
-            try {
+        $retryPolicy = new SimpleRetryPolicy(self::DATASET_CHECK_MAX_ATTEMPTS, [ServiceException::class]);
+        $backOffPolicy = new FixedBackOffPolicy(self::DATASET_CHECK_RETRY_DELAY_MS);
+        $retryProxy = new RetryProxy($retryPolicy, $backOffPolicy, $this->logger);
+
+        try {
+            $retryProxy->call(function () use ($dataset): void {
                 $dataset->reload();
-                $this->logger->info(sprintf(
-                    'Workspace dataset "%s" is accessible (attempt %d/%d).',
-                    $datasetName,
-                    $attempt,
-                    self::DATASET_CHECK_MAX_RETRIES,
-                ));
-                return;
-            } catch (ServiceException $e) {
-                if ($attempt < self::DATASET_CHECK_MAX_RETRIES) {
-                    $this->logger->info(sprintf(
-                        'Workspace dataset "%s" is not yet accessible (attempt %d/%d, HTTP %d).'
-                        . ' Retrying in %d seconds...',
-                        $datasetName,
-                        $attempt,
-                        self::DATASET_CHECK_MAX_RETRIES,
-                        $e->getCode(),
-                        self::DATASET_CHECK_RETRY_DELAY_SECONDS,
-                    ));
-                    sleep(self::DATASET_CHECK_RETRY_DELAY_SECONDS);
-                } else {
-                    throw new UserException(sprintf(
-                        'Workspace dataset "%s" is not accessible after %d attempts: %s',
-                        $datasetName,
-                        self::DATASET_CHECK_MAX_RETRIES,
-                        $e->getMessage(),
-                    ), 0, $e);
-                }
-            }
+            });
+            $this->logger->info(sprintf(
+                'Workspace dataset "%s" is accessible (attempt %d/%d).',
+                $datasetName,
+                $retryProxy->getTryCount(),
+                self::DATASET_CHECK_MAX_ATTEMPTS,
+            ));
+        } catch (ServiceException $e) {
+            throw new UserException(sprintf(
+                'Workspace dataset "%s" is not accessible after %d attempts: %s',
+                $datasetName,
+                self::DATASET_CHECK_MAX_ATTEMPTS,
+                $e->getMessage(),
+            ), 0, $e);
         }
     }
 

--- a/src/DwhProvider/LocalBigQueryProvider.php
+++ b/src/DwhProvider/LocalBigQueryProvider.php
@@ -9,6 +9,7 @@ use DbtTransformation\FileDumper\BigQueryDbtSourcesYaml;
 use DbtTransformation\FileDumper\DbtProfilesYaml;
 use DbtTransformation\FileDumper\DbtSourcesYaml;
 use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\BigQuery\Dataset;
 use Google\Cloud\Core\Exception\ServiceException;
 use Keboola\Component\UserException;
 use Keboola\StorageApi\Client;
@@ -45,8 +46,8 @@ class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
         $this->temp = new Temp('dbt-big-query-local');
     }
 
-    private const DATASET_CHECK_MAX_ATTEMPTS = 10;
-    private const DATASET_CHECK_RETRY_DELAY_MS = 3000;
+    protected const DATASET_CHECK_MAX_ATTEMPTS = 10;
+    protected const DATASET_CHECK_RETRY_DELAY_MS = 3000;
 
     /**
      * @param array<int, string> $configurationNames
@@ -104,12 +105,7 @@ class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
         $workspace = $this->config->getAuthorization()['workspace'];
         $datasetName = $workspace['schema'];
 
-        $bqClient = new BigQueryClient([
-            'keyFile' => $workspace['credentials'],
-            'location' => $workspace['region'],
-        ]);
-
-        $dataset = $bqClient->dataset($datasetName);
+        $dataset = $this->createBigQueryDataset($workspace, $datasetName);
 
         $retryPolicy = new SimpleRetryPolicy(self::DATASET_CHECK_MAX_ATTEMPTS, [ServiceException::class]);
         $backOffPolicy = new FixedBackOffPolicy(self::DATASET_CHECK_RETRY_DELAY_MS);
@@ -133,6 +129,19 @@ class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
                 $e->getMessage(),
             ), 0, $e);
         }
+    }
+
+    /**
+     * @param array<string, mixed> $workspace
+     */
+    protected function createBigQueryDataset(array $workspace, string $datasetName): Dataset
+    {
+        $bqClient = new BigQueryClient([
+            'keyFile' => $workspace['credentials'],
+            'location' => $workspace['region'],
+        ]);
+
+        return $bqClient->dataset($datasetName);
     }
 
     protected function setEnvVars(): void

--- a/src/DwhProvider/LocalBigQueryProvider.php
+++ b/src/DwhProvider/LocalBigQueryProvider.php
@@ -8,6 +8,9 @@ use DbtTransformation\Config;
 use DbtTransformation\FileDumper\BigQueryDbtSourcesYaml;
 use DbtTransformation\FileDumper\DbtProfilesYaml;
 use DbtTransformation\FileDumper\DbtSourcesYaml;
+use Google\Cloud\BigQuery\BigQueryClient;
+use Google\Cloud\Core\Exception\ServiceException;
+use Keboola\Component\UserException;
 use Keboola\StorageApi\Client;
 use Keboola\Temp\Temp;
 use Psr\Log\LoggerInterface;
@@ -38,6 +41,9 @@ class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
         $this->projectPath = $projectPath;
         $this->temp = new Temp('dbt-big-query-local');
     }
+
+    private const DATASET_CHECK_MAX_RETRIES = 10;
+    private const DATASET_CHECK_RETRY_DELAY_SECONDS = 3;
 
     /**
      * @param array<int, string> $configurationNames
@@ -70,6 +76,7 @@ class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
             $this->getOutputs($configurationNames, self::getDbtParams()),
         );
         $this->setEnvVars();
+        $this->waitForDatasetAccessibility();
 
         if ($this->config->generateSources()) {
             $this->createSourceFileService->dumpYaml(
@@ -77,6 +84,61 @@ class LocalBigQueryProvider extends DwhProvider implements DwhProviderInterface
                 $tablesData,
                 $this->config->getFreshness(),
             );
+        }
+    }
+
+    /**
+     * Verifies the workspace dataset is accessible to the workspace service account.
+     *
+     * After workspace creation, GCP IAM permissions may not be immediately effective
+     * due to eventual consistency. This pre-flight check retries dataset access
+     * to ensure dbt won't fail with a 403 error on CREATE SCHEMA IF NOT EXISTS.
+     *
+     * @throws \Keboola\Component\UserException
+     */
+    protected function waitForDatasetAccessibility(): void
+    {
+        $workspace = $this->config->getAuthorization()['workspace'];
+        $datasetName = $workspace['schema'];
+
+        $bqClient = new BigQueryClient([
+            'keyFile' => $workspace['credentials'],
+            'location' => $workspace['region'],
+        ]);
+
+        $dataset = $bqClient->dataset($datasetName);
+
+        for ($attempt = 1; $attempt <= self::DATASET_CHECK_MAX_RETRIES; $attempt++) {
+            try {
+                $dataset->reload();
+                $this->logger->info(sprintf(
+                    'Workspace dataset "%s" is accessible (attempt %d/%d).',
+                    $datasetName,
+                    $attempt,
+                    self::DATASET_CHECK_MAX_RETRIES,
+                ));
+                return;
+            } catch (ServiceException $e) {
+                if ($attempt < self::DATASET_CHECK_MAX_RETRIES) {
+                    $this->logger->info(sprintf(
+                        'Workspace dataset "%s" is not yet accessible (attempt %d/%d, HTTP %d).'
+                        . ' Retrying in %d seconds...',
+                        $datasetName,
+                        $attempt,
+                        self::DATASET_CHECK_MAX_RETRIES,
+                        $e->getCode(),
+                        self::DATASET_CHECK_RETRY_DELAY_SECONDS,
+                    ));
+                    sleep(self::DATASET_CHECK_RETRY_DELAY_SECONDS);
+                } else {
+                    throw new UserException(sprintf(
+                        'Workspace dataset "%s" is not accessible after %d attempts: %s',
+                        $datasetName,
+                        self::DATASET_CHECK_MAX_RETRIES,
+                        $e->getMessage(),
+                    ), 0, $e);
+                }
+            }
         }
     }
 

--- a/tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout
+++ b/tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout
@@ -1,5 +1,6 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-for-local-bigquery (%s)
 Generated profiles.yml: %A
+Workspace dataset "%s" is accessible (attempt %s).
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml

--- a/tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout
+++ b/tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout
@@ -1,6 +1,6 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-for-local-bigquery (%s)
-Generated profiles.yml: %A
 Workspace dataset "%s" is accessible (attempt %s).
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml

--- a/tests/functional/run-action-with-local-bigquery/expected-stdout
+++ b/tests/functional/run-action-with-local-bigquery/expected-stdout
@@ -1,5 +1,6 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-for-local-bigquery (%s)
 Generated profiles.yml: %A
+Workspace dataset "%s" is accessible (attempt %s).
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml

--- a/tests/functional/run-action-with-local-bigquery/expected-stdout
+++ b/tests/functional/run-action-with-local-bigquery/expected-stdout
@@ -1,6 +1,6 @@
 Successfully cloned repository https://github.com/keboola/dbt-test-project-public.git from branch branch-for-local-bigquery (%s)
-Generated profiles.yml: %A
 Workspace dataset "%s" is accessible (attempt %s).
+Generated profiles.yml: %A
 Executing command "dbt deps"
 Running with dbt=%A
 Warning: No packages were found in packages.yml

--- a/tests/phpunit/DwhProvider/LocalBigQueryProviderTest.php
+++ b/tests/phpunit/DwhProvider/LocalBigQueryProviderTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DbtTransformation\Tests\DwhProvider;
+
+use ColinODell\PsrTestLogger\TestLogger;
+use DbtTransformation\Config;
+use DbtTransformation\Configuration\ConfigDefinition;
+use DbtTransformation\FileDumper\BigQueryDbtSourcesYaml;
+use DbtTransformation\FileDumper\DbtProfilesYaml;
+use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\Core\Exception\ServiceException;
+use Keboola\Component\UserException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class LocalBigQueryProviderTest extends TestCase
+{
+    private TestLogger $logger;
+
+    protected function setUp(): void
+    {
+        $this->logger = new TestLogger();
+    }
+
+    private function createConfig(): Config
+    {
+        return new Config([
+            'authorization' => [
+                'workspace' => [
+                    'schema' => 'WORKSPACE_12345',
+                    'region' => 'europe-west3',
+                    'credentials' => [
+                        'type' => 'service_account',
+                        'project_id' => 'test-project',
+                        'private_key_id' => 'key-id',
+                        'private_key' => 'key',
+                        'client_email' => 'test@test.iam.gserviceaccount.com',
+                        'client_id' => '123',
+                        'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
+                        'token_uri' => 'https://oauth2.googleapis.com/token',
+                        'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
+                        'client_x509_cert_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/test',
+                    ],
+                ],
+            ],
+            'parameters' => [
+                'git' => [
+                    'repo' => 'https://github.com/keboola/dbt-test-project-public.git',
+                ],
+                'dbt' => [
+                    'executeSteps' => [
+                        ['step' => 'dbt run', 'active' => true],
+                    ],
+                ],
+            ],
+        ], new ConfigDefinition());
+    }
+
+    private function createProvider(Dataset $dataset): TestableLocalBigQueryProvider
+    {
+        $config = $this->createConfig();
+
+        $createSourceFileService = $this->createMock(BigQueryDbtSourcesYaml::class);
+        $createProfilesFileService = $this->createMock(DbtProfilesYaml::class);
+
+        return new TestableLocalBigQueryProvider(
+            $createSourceFileService,
+            $createProfilesFileService,
+            $this->logger,
+            $config,
+            '/tmp/test-project',
+            $dataset,
+        );
+    }
+
+    public function testDatasetAccessibleOnFirstAttempt(): void
+    {
+        $dataset = $this->createMock(Dataset::class);
+        $dataset->expects(self::once())
+            ->method('reload');
+
+        $provider = $this->createProvider($dataset);
+        $provider->callWaitForDatasetAccessibility();
+
+        self::assertTrue($this->logger->hasInfoThatContains(
+            'Workspace dataset "WORKSPACE_12345" is accessible (attempt 1/10).',
+        ));
+    }
+
+    public function testDatasetAccessibleAfterRetries(): void
+    {
+        $dataset = $this->createMock(Dataset::class);
+        $dataset->expects(self::exactly(3))
+            ->method('reload')
+            ->willReturnOnConsecutiveCalls(
+                self::throwException(new ServiceException('Access denied', 403)),
+                self::throwException(new ServiceException('Access denied', 403)),
+                null,
+            );
+
+        $provider = $this->createProvider($dataset);
+        $provider->callWaitForDatasetAccessibility();
+
+        self::assertTrue($this->logger->hasInfoThatContains(
+            'Workspace dataset "WORKSPACE_12345" is accessible (attempt 3/10).',
+        ));
+        // RetryProxy logs retries automatically
+        self::assertTrue($this->logger->hasInfoThatContains('Access denied. Retrying... ['));
+    }
+
+    public function testDatasetNotAccessibleAfterAllAttempts(): void
+    {
+        $dataset = $this->createMock(Dataset::class);
+        $dataset->expects(self::exactly(10))
+            ->method('reload')
+            ->willThrowException(new ServiceException('Permission denied', 403));
+
+        $provider = $this->createProvider($dataset);
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage(
+            'Workspace dataset "WORKSPACE_12345" is not accessible after 10 attempts: Permission denied',
+        );
+
+        $provider->callWaitForDatasetAccessibility();
+    }
+
+    public function testNonServiceExceptionIsNotRetried(): void
+    {
+        $dataset = $this->createMock(Dataset::class);
+        $dataset->expects(self::once())
+            ->method('reload')
+            ->willThrowException(new RuntimeException('Network error'));
+
+        $provider = $this->createProvider($dataset);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Network error');
+
+        $provider->callWaitForDatasetAccessibility();
+    }
+}

--- a/tests/phpunit/DwhProvider/TestableLocalBigQueryProvider.php
+++ b/tests/phpunit/DwhProvider/TestableLocalBigQueryProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DbtTransformation\Tests\DwhProvider;
+
+use DbtTransformation\Config;
+use DbtTransformation\DwhProvider\LocalBigQueryProvider;
+use DbtTransformation\FileDumper\BigQueryDbtSourcesYaml;
+use DbtTransformation\FileDumper\DbtProfilesYaml;
+use Google\Cloud\BigQuery\Dataset;
+use Google\Cloud\Core\Exception\ServiceException;
+use Keboola\Component\UserException;
+use Psr\Log\LoggerInterface;
+use Retry\BackOff\NoBackOffPolicy;
+use Retry\Policy\SimpleRetryPolicy;
+use Retry\RetryProxy;
+
+/**
+ * Testable subclass that overrides createBigQueryDataset() to return a mock
+ * and uses NoBackOffPolicy to avoid sleeping during tests.
+ */
+class TestableLocalBigQueryProvider extends LocalBigQueryProvider
+{
+    private Dataset $mockDataset;
+
+    public function __construct(
+        BigQueryDbtSourcesYaml $createSourceFileService,
+        DbtProfilesYaml $createProfilesFileService,
+        LoggerInterface $logger,
+        Config $config,
+        string $projectPath,
+        Dataset $mockDataset,
+    ) {
+        parent::__construct($createSourceFileService, $createProfilesFileService, $logger, $config, $projectPath);
+        $this->mockDataset = $mockDataset;
+    }
+
+    /**
+     * @param array<string, mixed> $workspace
+     */
+    protected function createBigQueryDataset(array $workspace, string $datasetName): Dataset
+    {
+        return $this->mockDataset;
+    }
+
+    public function callWaitForDatasetAccessibility(): void
+    {
+        $workspace = $this->config->getAuthorization()['workspace'];
+        $datasetName = $workspace['schema'];
+
+        $dataset = $this->createBigQueryDataset($workspace, $datasetName);
+
+        $retryPolicy = new SimpleRetryPolicy(self::DATASET_CHECK_MAX_ATTEMPTS, [ServiceException::class]);
+        $backOffPolicy = new NoBackOffPolicy();
+        $retryProxy = new RetryProxy($retryPolicy, $backOffPolicy, $this->logger);
+
+        try {
+            $retryProxy->call(function () use ($dataset): void {
+                $dataset->reload();
+            });
+            $this->logger->info(sprintf(
+                'Workspace dataset "%s" is accessible (attempt %d/%d).',
+                $datasetName,
+                $retryProxy->getTryCount(),
+                self::DATASET_CHECK_MAX_ATTEMPTS,
+            ));
+        } catch (ServiceException $e) {
+            throw new UserException(sprintf(
+                'Workspace dataset "%s" is not accessible after %d attempts: %s',
+                $datasetName,
+                self::DATASET_CHECK_MAX_ATTEMPTS,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a retry-based pre-flight check in `LocalBigQueryProvider` that verifies the workspace BigQuery dataset is accessible before dbt execution begins.

**Problem**: After workspace creation, GCP IAM permissions are subject to eventual consistency — the workspace service account may not be able to access its own dataset for several seconds. When dbt starts immediately and calls `list_datasets()` (via `check_schema_exists`), it may not see the workspace dataset, causing it to attempt `CREATE SCHEMA IF NOT EXISTS`, which fails with 403 because the workspace SA intentionally lacks `bigquery.datasets.create` at the project level. This produces intermittent failures.

**Fix**: Before dbt runs, the component now calls `dataset->reload()` (a `datasets.get` API call) using the workspace SA credentials, with retries powered by the `keboola/retry` library (`RetryProxy` + `SimpleRetryPolicy` + `FixedBackOffPolicy`). Once the dataset is confirmed accessible, dbt's `check_schema_exists` will find it and skip the `CREATE SCHEMA` attempt entirely.

**Retry parameters**: 10 max attempts, 3s fixed backoff between retries = ~30s max wait. Only `ServiceException` triggers retries. On exhaustion, wraps the last exception in a `UserException`.

### Changes
- `src/DwhProvider/LocalBigQueryProvider.php` — added `waitForDatasetAccessibility()` method using `RetryProxy` from `keboola/retry`, called from `createDbtYamlFiles()` after `setEnvVars()`. Extracted `createBigQueryDataset()` as a protected method for testability.
- `tests/functional/run-action-with-local-bigquery/expected-stdout` — added expected log line for the pre-flight check
- `tests/functional/run-action-with-local-bigquery-native-types-manifest/expected-stdout` — same
- `tests/phpunit/DwhProvider/LocalBigQueryProviderTest.php` — unit tests covering: success on first attempt, success after retries, failure after all attempts exhausted (`UserException`), and non-retryable exception passthrough
- `tests/phpunit/DwhProvider/TestableLocalBigQueryProvider.php` — test subclass that injects a mock `Dataset` and uses `NoBackOffPolicy` for instant retries

### Updates since last revision
- Added unit tests for `waitForDatasetAccessibility()` per review feedback, covering the retry and error paths that functional tests cannot exercise.
- Extracted `createBigQueryDataset()` into a protected method to allow dependency injection in tests without modifying production behavior.
- Changed `DATASET_CHECK_MAX_ATTEMPTS` and `DATASET_CHECK_RETRY_DELAY_MS` from `private` to `protected` so the test subclass can reference them.

## Review & Testing Checklist for Human

- [ ] **Verify the `dataset->reload()` call is sufficient** — this uses the `datasets.get` API, which requires `bigquery.datasets.get` permission. The core assumption is that the workspace SA has this via its dataset-level `DATA_OWNER` ACL (set during `createDataset()`) even before project-level IAM propagates. If `datasets.get` also requires project-level permissions to resolve the dataset, this check would fail even on retry — please confirm.
- [ ] **Review `TestableLocalBigQueryProvider.callWaitForDatasetAccessibility()` duplication** — the test subclass duplicates the retry logic from the production `waitForDatasetAccessibility()` method (replacing `FixedBackOffPolicy` with `NoBackOffPolicy`). If the production retry logic changes in the future, the test copy must be updated manually. Verify this tradeoff is acceptable.
- [ ] **Test with a real BigQuery workspace** — run a `keboola.dbt-transformation-local-bigquery` job and confirm the pre-flight check log line appears and the transformation succeeds. Ideally also test the retry path by triggering IAM propagation delay (e.g., running immediately after workspace creation).
- [ ] **Verify `TerminatedRetryException` handling** — if the retry policy itself throws, `RetryProxy` wraps it in `TerminatedRetryException` which is not caught here. This is unlikely but would surface as an unhandled exception rather than a `UserException`. Confirm this is acceptable.

### Notes
- The `credentials` key is passed as an array to `BigQueryClient::keyFile`, matching the existing pattern used in `Component.php:123-124` for `OutputManifestBigQuery`.
- CI functional tests use a long-lived workspace where IAM is already propagated, so they only exercise the "succeeds on first attempt" path. The new unit tests cover the retry and error paths via mocked `Dataset::reload()`.
- The `RetryProxy` automatically logs retry attempts in the format `"{exception message}. Retrying... [{count}x]"` — these lines will only appear in output when IAM propagation is delayed.

## Release Notes
**Justification, description**

Fixes intermittent 403 errors (`bigquery.datasets.create` permission denied) when running dbt transformations on BigQuery workspaces. The root cause is GCP IAM eventual consistency after workspace creation — the workspace service account may not immediately be able to access its own dataset. A pre-flight retry loop now ensures dataset accessibility before dbt execution begins.

**Plans for Customer Communication**

N/A — transparent fix, no configuration changes needed.

**Impact Analysis**

Adds one extra BigQuery API call (`datasets.get`) per local BigQuery transformation run. In the rare case of IAM propagation delay, adds up to ~30 seconds of wait time (vs. the previous behavior of an immediate 403 failure).

**Deployment Plan**

Standard deployment via Developer Portal tag push.

**Rollback Plan**

Revert the commit and redeploy.

**Post-Release Support Plan**

Monitor Datadog logs for `componentid:keboola.dbt-transformation-local-bigquery` to confirm reduced 403 error rate on `CREATE SCHEMA IF NOT EXISTS`.

Link to Devin session: https://app.devin.ai/sessions/892dbe5662444cb89dc2eff09735bf01
Requested by: @MiroCillik
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/dbt-transformation/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
