### PR TITLE
chore: upgrade Snowflake ODBC driver 3.10.0 → 3.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,10 @@ ENV DBT_VERSION=${DBT_VERSION}
 ARG COMPOSER_FLAGS="--prefer-dist --no-interaction"
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG SNOWFLAKE_ODBC_VERSION=3.10.0
-ARG SNOWFLAKE_GPG_KEY=2A3149C82551A34A
+ARG SNOWFLAKE_ODBC_VERSION=3.18.0
+# Full 40-char fingerprint of the Snowflake signing key for 3.18.0 (key id
+# 3C98F63C9292CE02); trixie's debsig-verify resolves the policy dir by full fingerprint
+ARG SNOWFLAKE_GPG_KEY=6C983AB7AFE2E5951C6C47B13C98F63C9292CE02
 
 ENV LANGUAGE=en_US.UTF-8
 ENV LANG=en_US.UTF-8
@@ -47,6 +49,7 @@ RUN apt-get update && \
             debsig-verify \
             unixodbc \
             unixodbc-dev \
+            odbcinst \
     && apt-get clean
 
 # Compile and install Python 3.11 from source

--- a/docker/snowflake/generic.pol
+++ b/docker/snowflake/generic.pol
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <!DOCTYPE Policy SYSTEM "http://www.debian.org/debsig/1.0/policy.dtd">
 <Policy xmlns="https://www.debian.org/debsig/1.0/">
-<Origin Name="Snowflake Computing" id="2A3149C82551A34A"
+<Origin Name="Snowflake Computing" id="6C983AB7AFE2E5951C6C47B13C98F63C9292CE02"
 Description="Snowflake ODBC Driver DEB package"/>
 <Selection>
-<Required Type="origin" File="debsig.gpg" id="2A3149C82551A34A"/>
+<Required Type="origin" File="debsig.gpg" id="6C983AB7AFE2E5951C6C47B13C98F63C9292CE02"/>
 </Selection>
 <Verification MinOptional="0">
-<Required Type="origin" File="debsig.gpg" id="2A3149C82551A34A"/>
+<Required Type="origin" File="debsig.gpg" id="6C983AB7AFE2E5951C6C47B13C98F63C9292CE02"/>
 </Verification>
 </Policy>


### PR DESCRIPTION
Linear: [DMD-1659](https://linear.app/keboola/issue/DMD-1659/snowflake-odbc-driver-audit-upgrade-3100-3180-across-keboola-org)

## What
- `SNOWFLAKE_ODBC_VERSION` 3.10.0 → 3.18.0
- `SNOWFLAKE_GPG_KEY` → `6C983AB7AFE2E5951C6C47B13C98F63C9292CE02` — 3.18.0 is signed by a new key; trixie's debsig-verify (0.33) resolves the policy dir by the full 40-char issuer fingerprint. Same ids updated in `docker/snowflake/generic.pol`.
- Added `odbcinst` apt package — snowflake-odbc 3.18.0 declares `Depends: odbcinst` (split out of unixodbc in trixie) and `dpkg -i` does not resolve dependencies.

## Why
Snowflake recommends upgrading the ODBC driver to 3.18.0; org-wide rollout tracked in DMD-1659. Same recipe already merged in keboola/connection#7765, keboola/db-extractor-snowflake#170 and the three db-writer-snowflake* repos.

## Validation
Local `docker build` passes: `debsig: Verified package from 'Snowflake ODBC Driver DEB package' (Snowflake Computing)` + `Setting up snowflake-odbc (3.18.0)`. Smoke test in the built image: `SnowflakeDSIIDriver` registered, PHP `odbc` extension loaded, `dpkg -s snowflake-odbc` → 3.18.0.

Functional tests run in CI.